### PR TITLE
Remove the_silver_searcher from Brewfile.

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -86,7 +86,6 @@ brew 'ruby-build'
 brew 'telnet'
 brew 'terminal-notifier'
 brew 'tfenv'
-brew 'the_silver_searcher'
 brew 'tig'
 brew 'tldr'
 brew 'tmux', args: ['--HEAD']


### PR DESCRIPTION
Replaced by [ripgrep](https://github.com/BurntSushi/ripgrep).