### PR TITLE
Add tts setup command and venv-missing error handling

### DIFF
--- a/cmd/tts/daemon.go
+++ b/cmd/tts/daemon.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -119,7 +120,7 @@ func daemonRunning() bool {
 
 func runDaemon(background bool) error {
 	if !kokoroAvailable() {
-		return fmt.Errorf(errNoVenv)
+		return errors.New(errNoVenv)
 	}
 	scriptPath := filepath.Join(filepath.Dir(kokoroPython), "..", "serve.py")
 	// Only rewrite if content has changed to avoid unnecessary TOCTOU window.

--- a/cmd/tts/daemon.go
+++ b/cmd/tts/daemon.go
@@ -118,6 +118,9 @@ func daemonRunning() bool {
 }
 
 func runDaemon(background bool) error {
+	if !kokoroAvailable() {
+		return fmt.Errorf(errNoVenv)
+	}
 	scriptPath := filepath.Join(filepath.Dir(kokoroPython), "..", "serve.py")
 	// Only rewrite if content has changed to avoid unnecessary TOCTOU window.
 	existing, err := os.ReadFile(scriptPath)

--- a/cmd/tts/root.go
+++ b/cmd/tts/root.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,8 +32,11 @@ var playCmd = "afplay"
 // lockPath is the file used for cross-process mutual exclusion of playback.
 var lockPath = "/tmp/tts.lock"
 
+// kokoroVenvDir is the Kokoro TTS Python venv directory, overridable for testing.
+var kokoroVenvDir = filepath.Join(os.Getenv("HOME"), ".kokoro-tts")
+
 // kokoroPython is the path to the Kokoro venv Python, overridable for testing.
-var kokoroPython = filepath.Join(os.Getenv("HOME"), ".kokoro-tts", "bin", "python3")
+var kokoroPython = filepath.Join(kokoroVenvDir, "bin", "python3")
 
 // voiceMap maps OpenAI voice names to Kokoro voice IDs.
 var voiceMap = map[string]string{
@@ -58,10 +62,13 @@ const defaultVoice = "af_heart"
 // setupPkgs lists the Python packages installed by `tts setup`.
 var setupPkgs = []string{"kokoro", "soundfile", "huggingface_hub"}
 
-// kokoroAvailable returns true if the Kokoro venv Python binary exists.
+// kokoroAvailable returns true if the Kokoro venv Python binary exists and is executable.
 func kokoroAvailable() bool {
-	_, err := os.Stat(kokoroPython)
-	return err == nil
+	info, err := os.Stat(kokoroPython)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir() && info.Mode().Perm()&0111 != 0
 }
 
 // errNoVenv is the error message shown when the venv is missing.
@@ -237,10 +244,10 @@ func main() {
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
 			if kokoroAvailable() {
-				fmt.Println("Kokoro venv already exists at", filepath.Dir(kokoroPython))
+				fmt.Println("Kokoro venv already exists at", kokoroVenvDir)
 				return
 			}
-			venvDir := filepath.Dir(filepath.Dir(kokoroPython))
+			venvDir := kokoroVenvDir
 			fmt.Printf("Creating venv at %s...\n", venvDir)
 			if err := exec.Command("python3", "-m", "venv", venvDir).Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating venv: %v\n", err)
@@ -312,7 +319,7 @@ func speakLocal(text, voice string, speed float64) error {
 	}
 
 	if !kokoroAvailable() {
-		return fmt.Errorf(errNoVenv)
+		return errors.New(errNoVenv)
 	}
 
 	cached := ensureVoiceCached(voice)

--- a/cmd/tts/root.go
+++ b/cmd/tts/root.go
@@ -55,6 +55,18 @@ var validVoice = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 const defaultVoice = "af_heart"
 
+// setupPkgs lists the Python packages installed by `tts setup`.
+var setupPkgs = []string{"kokoro", "soundfile", "huggingface_hub"}
+
+// kokoroAvailable returns true if the Kokoro venv Python binary exists.
+func kokoroAvailable() bool {
+	_, err := os.Stat(kokoroPython)
+	return err == nil
+}
+
+// errNoVenv is the error message shown when the venv is missing.
+const errNoVenv = "kokoro venv not found — run `tts setup` first"
+
 // isVoiceCached checks if a Kokoro voice .pt file exists in the local HF cache.
 func isVoiceCached(voice string) bool {
 	if !validVoice.MatchString(voice) {
@@ -70,6 +82,10 @@ func ensureVoiceCached(voice string) bool {
 		return true
 	}
 	if !validVoice.MatchString(voice) {
+		return false
+	}
+	if !kokoroAvailable() {
+		fmt.Fprintln(os.Stderr, errNoVenv)
 		return false
 	}
 	// Download the missing voice file — pass voice as argv to avoid code injection
@@ -215,7 +231,35 @@ func main() {
 		},
 	}
 
-	root.AddCommand(serveCmd, stopCmd, cacheCmd)
+	setupCmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Create the Kokoro TTS Python venv and install dependencies",
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
+			if kokoroAvailable() {
+				fmt.Println("Kokoro venv already exists at", filepath.Dir(kokoroPython))
+				return
+			}
+			venvDir := filepath.Dir(filepath.Dir(kokoroPython))
+			fmt.Printf("Creating venv at %s...\n", venvDir)
+			if err := exec.Command("python3", "-m", "venv", venvDir).Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error creating venv: %v\n", err)
+				os.Exit(1)
+			}
+			pip := filepath.Join(venvDir, "bin", "pip")
+			fmt.Printf("Installing packages: %s\n", strings.Join(setupPkgs, ", "))
+			cmd := exec.Command(pip, append([]string{"install"}, setupPkgs...)...)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			if err := cmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error installing packages: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println("Setup complete.")
+		},
+	}
+
+	root.AddCommand(serveCmd, stopCmd, cacheCmd, setupCmd)
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
@@ -265,6 +309,10 @@ func playWithLock(audioPath string) error {
 func speakLocal(text, voice string, speed float64) error {
 	if micActive() {
 		return nil
+	}
+
+	if !kokoroAvailable() {
+		return fmt.Errorf(errNoVenv)
 	}
 
 	cached := ensureVoiceCached(voice)

--- a/cmd/tts/root_test.go
+++ b/cmd/tts/root_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -14,6 +16,19 @@ func stubMic(active bool) func() {
 	orig := micActive
 	micActive = func() bool { return active }
 	return func() { micActive = orig }
+}
+
+// stubPython creates a fake python3 (actually /usr/bin/true) in a temp dir
+// and overrides kokoroPython to point at it. Returns a cleanup function.
+func stubPython(t *testing.T) func() {
+	t.Helper()
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("true not found in PATH")
+	}
+	orig := kokoroPython
+	kokoroPython = truePath
+	return func() { kokoroPython = orig }
 }
 
 func TestEnsureVoiceCached_SkipsWhenPresent(t *testing.T) {
@@ -91,9 +106,7 @@ func TestSpeakLocal_FallsBackOnUncachedVoice(t *testing.T) {
 	hfCacheDir = dir
 	defer func() { hfCacheDir = orig }()
 
-	origPython := kokoroPython
-	kokoroPython = "true"
-	defer func() { kokoroPython = origPython }()
+	defer stubPython(t)()
 
 	origPlay := playCmd
 	playCmd = "true"
@@ -189,9 +202,7 @@ func TestSpeakLocal_SkipsWhenMicActive(t *testing.T) {
 func TestSpeakLocal_Success(t *testing.T) {
 	defer stubMic(false)()
 
-	origPython := kokoroPython
-	kokoroPython = "true"
-	defer func() { kokoroPython = origPython }()
+	defer stubPython(t)()
 
 	origPlay := playCmd
 	playCmd = "true"
@@ -264,6 +275,63 @@ func TestSpeakRemote_APIError(t *testing.T) {
 	}
 	if got := err.Error(); got != `OpenAI API error (401): {"error": "invalid api key"}` {
 		t.Errorf("unexpected error message: %q", got)
+	}
+}
+
+func TestKokoroAvailable_True(t *testing.T) {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	os.MkdirAll(binDir, 0755)
+	py := filepath.Join(binDir, "python3")
+	os.WriteFile(py, []byte("#!/bin/sh\n"), 0755)
+
+	orig := kokoroPython
+	kokoroPython = py
+	defer func() { kokoroPython = orig }()
+
+	if !kokoroAvailable() {
+		t.Error("expected true when python3 exists")
+	}
+}
+
+func TestKokoroAvailable_False(t *testing.T) {
+	orig := kokoroPython
+	kokoroPython = "/nonexistent/path/python3"
+	defer func() { kokoroPython = orig }()
+
+	if kokoroAvailable() {
+		t.Error("expected false when python3 does not exist")
+	}
+}
+
+func TestSpeakLocal_ErrorsWhenNoVenv(t *testing.T) {
+	defer stubMic(false)()
+
+	orig := kokoroPython
+	kokoroPython = "/nonexistent/path/python3"
+	defer func() { kokoroPython = orig }()
+
+	err := speakLocal("test", "af_heart", 1.0)
+	if err == nil {
+		t.Fatal("expected error when venv missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "tts setup") {
+		t.Errorf("error should mention 'tts setup', got: %v", err)
+	}
+}
+
+func TestEnsureVoiceCached_ErrorsWhenNoVenv(t *testing.T) {
+	dir := t.TempDir()
+	orig := hfCacheDir
+	hfCacheDir = dir
+	defer func() { hfCacheDir = orig }()
+
+	origPython := kokoroPython
+	kokoroPython = "/nonexistent/path/python3"
+	defer func() { kokoroPython = origPython }()
+
+	if ensureVoiceCached("af_alloy") {
+		t.Error("expected false when venv missing")
 	}
 }
 

--- a/cmd/tts/root_test.go
+++ b/cmd/tts/root_test.go
@@ -18,8 +18,8 @@ func stubMic(active bool) func() {
 	return func() { micActive = orig }
 }
 
-// stubPython creates a fake python3 (actually /usr/bin/true) in a temp dir
-// and overrides kokoroPython to point at it. Returns a cleanup function.
+// stubPython overrides kokoroPython to point at the system `true` binary
+// so that kokoroAvailable() passes. Returns a cleanup function.
 func stubPython(t *testing.T) func() {
 	t.Helper()
 	truePath, err := exec.LookPath("true")


### PR DESCRIPTION
Adds `tts setup` subcommand to create the Kokoro TTS Python venv and install dependencies. All local-TTS paths now check for the venv and print a clear error message instead of a cryptic fork/exec failure.

Co-Authored-By: Claude <noreply@anthropic.com>