### PR TITLE
Fix tts setup: auto-detect Python 3.12+, upgrade pip, cache model

### DIFF
--- a/cmd/tts/daemon.go
+++ b/cmd/tts/daemon.go
@@ -131,7 +131,11 @@ func runDaemon(background bool) error {
 		}
 	}
 	cmd := exec.Command(kokoroPython, scriptPath)
-	cmd.Env = append(os.Environ(), "PYTORCH_ENABLE_MPS_FALLBACK=1", "HF_HUB_OFFLINE=1")
+	env := append(os.Environ(), "PYTORCH_ENABLE_MPS_FALLBACK=1")
+	if isModelCached() {
+		env = append(env, "HF_HUB_OFFLINE=1")
+	}
+	cmd.Env = env
 	if background {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 		return cmd.Start()

--- a/cmd/tts/root.go
+++ b/cmd/tts/root.go
@@ -74,6 +74,59 @@ func kokoroAvailable() bool {
 // errNoVenv is the error message shown when the venv is missing.
 const errNoVenv = "kokoro venv not found — run `tts setup` first"
 
+// findPython returns the best Python 3.10+ binary for creating the venv.
+// It prefers stable, well-supported versions (3.12, 3.13) over bleeding-edge
+// ones where ML packages may lack wheels.
+func findPython() string {
+	// Preferred order: 3.12 and 3.13 have broad ML package support;
+	// 3.14+ may lack wheels for torch/spacy; 3.10-3.11 are acceptable fallbacks.
+	candidates := []string{
+		"python3.12", "python3.13", "python3.11", "python3.10", "python3.14",
+	}
+	for _, c := range candidates {
+		if p, err := exec.LookPath(c); err == nil {
+			return p
+		}
+	}
+	// Fall back to whatever python3 resolves to.
+	if p, err := exec.LookPath("python3"); err == nil {
+		return p
+	}
+	return "python3"
+}
+
+// isModelCached checks if the Kokoro model config exists in the local HF cache.
+func isModelCached() bool {
+	matches, err := filepath.Glob(filepath.Join(hfCacheDir, "*", "config.json"))
+	return err == nil && len(matches) > 0
+}
+
+// ensureModelCached downloads the Kokoro model files if not already cached.
+func ensureModelCached() bool {
+	if isModelCached() {
+		return true
+	}
+	if !kokoroAvailable() {
+		return false
+	}
+	script := "from kokoro import KModel; KModel(repo_id='hexgrad/Kokoro-82M')"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, kokoroPython, "-c", script)
+	var filtered []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "HF_HUB_OFFLINE=") {
+			filtered = append(filtered, e)
+		}
+	}
+	cmd.Env = filtered
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to cache model: %v\n", err)
+	}
+	return isModelCached()
+}
+
 // isVoiceCached checks if a Kokoro voice .pt file exists in the local HF cache.
 func isVoiceCached(voice string) bool {
 	if !validVoice.MatchString(voice) {
@@ -209,9 +262,18 @@ func main() {
 
 	cacheCmd := &cobra.Command{
 		Use:   "cache VOICE [VOICE...]",
-		Short: "Pre-download Kokoro voice files for offline use (e.g. alloy, af_alloy)",
+		Short: "Pre-download Kokoro model and voice files for offline use (e.g. alloy, af_alloy)",
 		Args:  cobra.MinimumNArgs(1),
 		Run: func(_ *cobra.Command, args []string) {
+			if !isModelCached() {
+				fmt.Println("model: downloading...")
+				if ensureModelCached() {
+					fmt.Println("model: cached")
+				} else {
+					fmt.Fprintln(os.Stderr, "model: failed to cache")
+					os.Exit(1)
+				}
+			}
 			failed := false
 			for _, name := range args {
 				resolved := resolveVoice(name)
@@ -238,22 +300,36 @@ func main() {
 		},
 	}
 
+	var setupForce bool
 	setupCmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Create the Kokoro TTS Python venv and install dependencies",
 		Args:  cobra.NoArgs,
 		Run: func(_ *cobra.Command, _ []string) {
-			if kokoroAvailable() {
-				fmt.Println("Kokoro venv already exists at", kokoroVenvDir)
+			venvDir := kokoroVenvDir
+			if kokoroAvailable() && !setupForce {
+				fmt.Println("Kokoro venv already exists at", venvDir)
+				fmt.Println("Run with --force to recreate.")
 				return
 			}
-			venvDir := kokoroVenvDir
-			fmt.Printf("Creating venv at %s...\n", venvDir)
-			if err := exec.Command("python3", "-m", "venv", venvDir).Run(); err != nil {
+			if setupForce {
+				fmt.Printf("Removing existing venv at %s...\n", venvDir)
+				os.RemoveAll(venvDir)
+			}
+			pythonBin := findPython()
+			fmt.Printf("Creating venv at %s (using %s)...\n", venvDir, pythonBin)
+			if err := exec.Command(pythonBin, "-m", "venv", venvDir).Run(); err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating venv: %v\n", err)
 				os.Exit(1)
 			}
 			pip := filepath.Join(venvDir, "bin", "pip")
+			fmt.Println("Upgrading pip...")
+			upCmd := exec.Command(pip, "install", "--upgrade", "pip")
+			upCmd.Stdout = os.Stdout
+			upCmd.Stderr = os.Stderr
+			if err := upCmd.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to upgrade pip: %v\n", err)
+			}
 			fmt.Printf("Installing packages: %s\n", strings.Join(setupPkgs, ", "))
 			cmd := exec.Command(pip, append([]string{"install"}, setupPkgs...)...)
 			cmd.Stdout = os.Stdout
@@ -265,6 +341,7 @@ func main() {
 			fmt.Println("Setup complete.")
 		},
 	}
+	setupCmd.Flags().BoolVar(&setupForce, "force", false, "Remove and recreate the venv from scratch")
 
 	root.AddCommand(serveCmd, stopCmd, cacheCmd, setupCmd)
 
@@ -343,7 +420,7 @@ func speakLocal(text, voice string, speed float64) error {
 
 		cmd := exec.Command(kokoroPython, "-c", kokoroScript, text, voice, fmt.Sprintf("%.2f", speed), tmp.Name())
 		env := append(os.Environ(), "PYTORCH_ENABLE_MPS_FALLBACK=1")
-		if cached {
+		if cached && isModelCached() {
 			env = append(env, "HF_HUB_OFFLINE=1")
 		}
 		cmd.Env = env

--- a/cmd/tts/root.go
+++ b/cmd/tts/root.go
@@ -59,6 +59,9 @@ var validVoice = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 
 const defaultVoice = "af_heart"
 
+// kokoroRepoID is the HuggingFace repository for the Kokoro TTS model.
+const kokoroRepoID = "hexgrad/Kokoro-82M"
+
 // setupPkgs lists the Python packages installed by `tts setup`.
 var setupPkgs = []string{"kokoro", "soundfile", "huggingface_hub"}
 
@@ -95,10 +98,25 @@ func findPython() string {
 	return "python3"
 }
 
-// isModelCached checks if the Kokoro model config exists in the local HF cache.
+// envWithoutHFOffline returns os.Environ() with HF_HUB_OFFLINE removed so downloads can proceed.
+func envWithoutHFOffline() []string {
+	var filtered []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "HF_HUB_OFFLINE=") {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}
+
+// isModelCached checks if the Kokoro model files (config + weights) exist in the local HF cache.
 func isModelCached() bool {
-	matches, err := filepath.Glob(filepath.Join(hfCacheDir, "*", "config.json"))
-	return err == nil && len(matches) > 0
+	cfgMatches, err := filepath.Glob(filepath.Join(hfCacheDir, "*", "config.json"))
+	if err != nil || len(cfgMatches) == 0 {
+		return false
+	}
+	wgtMatches, err := filepath.Glob(filepath.Join(hfCacheDir, "*", "kokoro*.pth"))
+	return err == nil && len(wgtMatches) > 0
 }
 
 // ensureModelCached downloads the Kokoro model files if not already cached.
@@ -109,17 +127,11 @@ func ensureModelCached() bool {
 	if !kokoroAvailable() {
 		return false
 	}
-	script := "from kokoro import KModel; KModel(repo_id='hexgrad/Kokoro-82M')"
+	script := "from kokoro import KModel; KModel(repo_id='" + kokoroRepoID + "')"
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, kokoroPython, "-c", script)
-	var filtered []string
-	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "HF_HUB_OFFLINE=") {
-			filtered = append(filtered, e)
-		}
-	}
-	cmd.Env = filtered
+	cmd.Env = envWithoutHFOffline()
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to cache model: %v\n", err)
@@ -149,18 +161,11 @@ func ensureVoiceCached(voice string) bool {
 		return false
 	}
 	// Download the missing voice file — pass voice as argv to avoid code injection
-	script := "import sys; from huggingface_hub import hf_hub_download; hf_hub_download('hexgrad/Kokoro-82M', 'voices/' + sys.argv[1] + '.pt')"
+	script := "import sys; from huggingface_hub import hf_hub_download; hf_hub_download('" + kokoroRepoID + "', 'voices/' + sys.argv[1] + '.pt')"
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, kokoroPython, "-c", script, voice)
-	// Filter out existing HF_HUB_OFFLINE so the download can proceed
-	var filtered []string
-	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, "HF_HUB_OFFLINE=") {
-			filtered = append(filtered, e)
-		}
-	}
-	cmd.Env = filtered
+	cmd.Env = envWithoutHFOffline()
 	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to cache voice %s: %v\n", voice, err)
 	}
@@ -312,7 +317,7 @@ func main() {
 				fmt.Println("Run with --force to recreate.")
 				return
 			}
-			if setupForce {
+			if setupForce && venvDir != "" {
 				fmt.Printf("Removing existing venv at %s...\n", venvDir)
 				os.RemoveAll(venvDir)
 			}

--- a/cmd/tts/root_test.go
+++ b/cmd/tts/root_test.go
@@ -304,6 +304,33 @@ func TestKokoroAvailable_False(t *testing.T) {
 	}
 }
 
+func TestFindPython_ReturnsExecutable(t *testing.T) {
+	p := findPython()
+	if p == "" {
+		t.Fatal("findPython returned empty string")
+	}
+	// The returned path should be executable.
+	info, err := os.Stat(p)
+	if err != nil {
+		t.Skipf("findPython returned %q which does not exist on this system", p)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Errorf("findPython returned %q which is not executable", p)
+	}
+}
+
+func TestFindPython_FallsBackToPython3(t *testing.T) {
+	// When PATH is empty, findPython should still return "python3" as fallback.
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", "")
+	defer os.Setenv("PATH", origPath)
+
+	p := findPython()
+	if p != "python3" {
+		t.Errorf("expected fallback to 'python3', got %q", p)
+	}
+}
+
 func TestSpeakLocal_ErrorsWhenNoVenv(t *testing.T) {
 	defer stubMic(false)()
 

--- a/cmd/tts/root_test.go
+++ b/cmd/tts/root_test.go
@@ -321,9 +321,7 @@ func TestFindPython_ReturnsExecutable(t *testing.T) {
 
 func TestFindPython_FallsBackToPython3(t *testing.T) {
 	// When PATH is empty, findPython should still return "python3" as fallback.
-	origPath := os.Getenv("PATH")
 	t.Setenv("PATH", "")
-	defer os.Setenv("PATH", origPath)
 
 	p := findPython()
 	if p != "python3" {


### PR DESCRIPTION
Three issues prevented tts setup from completing: system Python 3.9 too old for kokoro deps, bundled pip too old to find torch, and no way to retry after partial failure. Adds findPython() for version detection, pip upgrade step, --force flag for venv recreation, and model file caching alongside voice files.

Co-Authored-By: Claude <noreply@anthropic.com>