### PR TITLE
Add Safari support to hs browser bindings

### DIFF
--- a/hammerspoon/browser.lua
+++ b/hammerspoon/browser.lua
@@ -16,6 +16,7 @@ end
 function browser.openProfileMenu()
   local app = app()
   if app == nil then return end
+  if app:name() == 'Safari' then return end
   app:activate()
   -- focus on menubar if auto-hidden
   hs.eventtap.keyStroke({'fn', 'ctrl'}, 'f2')
@@ -26,10 +27,9 @@ function browser.closeOtherTabs()
   local app = app()
   if app == nil then return end
   alert.show('Closing Other Tabs')
-  local name = app:name()
-  local _cmd
-  if name == 'Safari' then
-    _cmd = [[
+  -- Safari uses object identity; Chromium browsers use active tab index
+  local scripts = {
+    ['Safari'] = [[
       tell application "Safari"
         set currentTab to current tab of window 1
         set tabList to every tab of window 1
@@ -39,10 +39,9 @@ function browser.closeOtherTabs()
           end if
         end repeat
       end tell
-    ]]
-  else
-    _cmd = ([[
-      tell application "]] .. name .. [["
+    ]],
+    ['Brave Browser'] = [[
+      tell application "Brave Browser"
         set tabList to every tab of window 1
         set activeTabIndex to active tab index of window 1
         set counter to 1
@@ -53,8 +52,10 @@ function browser.closeOtherTabs()
           set counter to counter + 1
         end repeat
       end tell
-    ]])
-  end
+    ]]
+  }
+  local _cmd = scripts[app:name()]
+  if _cmd == nil then return end
   as.applescript(_cmd)
 end
 

--- a/hammerspoon/browser.lua
+++ b/hammerspoon/browser.lua
@@ -3,9 +3,11 @@ local browser = {}
 local as = require 'hs.applescript'
 local alert = require 'alert'
 
+local browsers = { ['Brave Browser'] = true, ['Safari'] = true }
+
 local function app()
   local app = hs.application.frontmostApplication()
-  if app:name() == 'Brave Browser' then
+  if browsers[app:name()] then
     return app
   end
   return nil
@@ -24,19 +26,35 @@ function browser.closeOtherTabs()
   local app = app()
   if app == nil then return end
   alert.show('Closing Other Tabs')
-  local _cmd = ([[
-    tell application "]] .. app:name() .. [["
-      set tabList to every tab of window 1
-      set activeTabIndex to active tab index of window 1
-      set counter to 1
-      repeat with thisTab in tabList
-        if counter is not equal to activeTabIndex then
-          close thisTab
-        end if
-        set counter to counter + 1
-      end repeat
-    end tell
-  ]])
+  local name = app:name()
+  local _cmd
+  if name == 'Safari' then
+    _cmd = [[
+      tell application "Safari"
+        set currentTab to current tab of window 1
+        set tabList to every tab of window 1
+        repeat with thisTab in tabList
+          if thisTab is not currentTab then
+            close thisTab
+          end if
+        end repeat
+      end tell
+    ]]
+  else
+    _cmd = ([[
+      tell application "]] .. name .. [["
+        set tabList to every tab of window 1
+        set activeTabIndex to active tab index of window 1
+        set counter to 1
+        repeat with thisTab in tabList
+          if counter is not equal to activeTabIndex then
+            close thisTab
+          end if
+          set counter to counter + 1
+        end repeat
+      end tell
+    ]])
+  end
   as.applescript(_cmd)
 end
 


### PR DESCRIPTION
Add Safari to the browser module: close-other-tabs binding uses Safari-specific AppleScript with object identity comparison, and openProfileMenu is guarded to skip Safari (no Profiles menu). Refactored to dispatch table pattern eliminating string interpolation.

Co-Authored-By: Claude <noreply@anthropic.com>