### PR TITLE
Fix tmux-status Offline on non-en7 ethernet

### DIFF
--- a/cmd/tmux-status/left/root.go
+++ b/cmd/tmux-status/left/root.go
@@ -73,7 +73,7 @@ func second() string {
 }
 
 func localIP() string {
-	return run.Capture("ip --local en7 || ip --local || echo 127.0.0.1")
+	return run.Capture("ip --local $(route -n get default | awk '/interface:/{print $2}') || echo 127.0.0.1")
 }
 
 func externalIP() string {

--- a/cmd/tmux-status/left/root.go
+++ b/cmd/tmux-status/left/root.go
@@ -62,18 +62,23 @@ func first() string {
 }
 
 func second() string {
+	ip := localIP()
 	ssid := run.Capture("ssid --short")
 	if ssid != "" {
-		return fmt.Sprintf("%s %s %s", ssid, sep.R2, localIP())
+		return fmt.Sprintf("%s %s %s", ssid, sep.R2, ip)
 	}
-	if ip := localIP(); ip != "127.0.0.1" {
+	if ip != "127.0.0.1" {
 		return fmt.Sprintf("Ethernet %s %s", sep.R2, ip)
 	}
 	return "Offline"
 }
 
 func localIP() string {
-	return run.Capture("ip --local $(route -n get default | awk '/interface:/{print $2}') || echo 127.0.0.1")
+	iface := run.Capture("route -n get default | awk '/interface:/{print $2}'")
+	if iface == "" {
+		return "127.0.0.1"
+	}
+	return run.Capture("ip --local %s || echo 127.0.0.1", iface)
 }
 
 func externalIP() string {


### PR DESCRIPTION
## Summary

The tmux status-line `localIP()` function hardcoded `en7` as the ethernet interface. On machines where the active adapter is on a different interface (e.g. `en8` for a USB 2.5G LAN dongle), the status line displayed "Offline" despite a working connection.

## Changes

- Detect the active interface dynamically via `route -n get default` instead of hardcoding `en7`.
- Resolve the interface in Go and pass it as a safe argument to `ip --local` — removes the shell `$()` substitution and prevents the offline path from silently falling through to `en0` (which could otherwise leak a 169.254.x.x link-local address as "Ethernet").
- Call `localIP()` once per `second()` invocation instead of twice on the wired path.

## Test plan

- [x] `go install ./...` / `revive` / `go test ./...` / skill tests / skill lint all pass
- [x] `tmux-status left 200` shows correct IP on machine with active ethernet on `en8`

Co-Authored-By: Claude <noreply@anthropic.com>