### PR TITLE
Improve /rereview and /ship guidance from session feedback

### DIFF
--- a/agents/skills/rereview/SKILL.md
+++ b/agents/skills/rereview/SKILL.md
@@ -229,7 +229,7 @@ Go through the diff line by line. For each hunk:
 
 ## Output Format
 
-**Length budget:** keep your full report under 4 KB. Use one-line entries in tables; one or two sentences per finding. Don't reproduce code in the report — just file:line references. Reports that exceed the budget get truncated by the agent reply layer, and a truncated report is worse than a tight one. If you have many findings, prioritize BLOCKING > WARNING > INFO and keep INFO terse.
+**Length budget:** keep your individual report (you are one of three reviewers — this budget is per-reviewer, not for all three combined) under 4 KB. Use one-line entries in tables; one or two sentences per finding. Don't reproduce code in the report — just file:line references. Long reports tend to get truncated when returned to the coordinator, and a truncated report is worse than a tight one. If you have many findings, prioritize BLOCKING > WARNING > INFO and keep INFO terse.
 
 Classify every finding as:
 - **BLOCKING**: Must fix before merging. Includes: any unintentional behavior change, any regression risk without test coverage, any security issue, any broken API contract.

--- a/agents/skills/rereview/SKILL.md
+++ b/agents/skills/rereview/SKILL.md
@@ -192,6 +192,8 @@ Check every item -- do not skip any:
 - [ ] SSRF potential
 - [ ] Open redirect potential
 
+**Auth-gate symmetry check:** When evaluating destructive or configuration-mutating endpoints for auth gates, enumerate **every** parallel CRUD group in the routes table (e.g., projects + backends + tokens). Flag any group where some members are gated and others aren't. Asymmetry is a bug — if `DELETE /projects/:id` requires master auth but `DELETE /backends/:id` doesn't, that is almost certainly an oversight, not an intentional policy. Do not stop after finding one or two examples; walk the full route list.
+
 ### Analysis 4: Architecture and Design
 
 Check every item:
@@ -226,6 +228,8 @@ Go through the diff line by line. For each hunk:
 ---
 
 ## Output Format
+
+**Length budget:** keep your full report under 4 KB. Use one-line entries in tables; one or two sentences per finding. Don't reproduce code in the report — just file:line references. Reports that exceed the budget get truncated by the agent reply layer, and a truncated report is worse than a tight one. If you have many findings, prioritize BLOCKING > WARNING > INFO and keep INFO terse.
 
 Classify every finding as:
 - **BLOCKING**: Must fix before merging. Includes: any unintentional behavior change, any regression risk without test coverage, any security issue, any broken API contract.

--- a/agents/skills/ship/SKILL.md
+++ b/agents/skills/ship/SKILL.md
@@ -62,7 +62,7 @@ Print:
 
 Invoke the `/review` skill to analyze the current branch changes. Wait for the full report.
 
-**Even if `/rereview` ran recently, still run `/review`.** The two skills use different prompts and surface different patterns: `/rereview` is depth-first with three independent reviewers and tends to catch security and regression risks; `/review` is breadth-first and tends to catch consistency and asymmetry issues that depth-first review misses. They are complementary, not redundant. Do not skip Phase 1 just because `/rereview` was clean.
+**Even if `/rereview` ran recently, still run `/review`.** The two skills use different prompts and surface different patterns: `/rereview` is depth-first with three independent reviewers and tends to catch security and regression risks; `/review` is breadth-first and tends to catch consistency and asymmetry issues that depth-first review misses. They are complementary, not redundant. Do not skip Phase 1 just because `/rereview` was clean. **Phase 2 acts on `/review`'s findings only** — any prior `/rereview` output is informational background, not a substitute for this phase's input.
 
 If the review returns **no blocking issues, no warnings, and no suggestions**, print:
 

--- a/agents/skills/ship/SKILL.md
+++ b/agents/skills/ship/SKILL.md
@@ -62,6 +62,8 @@ Print:
 
 Invoke the `/review` skill to analyze the current branch changes. Wait for the full report.
 
+**Even if `/rereview` ran recently, still run `/review`.** The two skills use different prompts and surface different patterns: `/rereview` is depth-first with three independent reviewers and tends to catch security and regression risks; `/review` is breadth-first and tends to catch consistency and asymmetry issues that depth-first review misses. They are complementary, not redundant. Do not skip Phase 1 just because `/rereview` was clean.
+
 If the review returns **no blocking issues, no warnings, and no suggestions**, print:
 
 > Review clean — skipping to Phase 3.
@@ -144,6 +146,8 @@ Print:
 Invoke the `/merge` skill to land the branch into master.
 
 Handle merge script exit codes as documented in the `/merge` skill (conflicts, nothing to merge, review blocked, errors).
+
+**If CI fails on tests unrelated to your PR**, fix them inline as part of `/ship` rather than rebasing or treating the merge as blocked. Pre-existing flakes (timing-sensitive tests, data races on shared mutable state, environment-dependent assertions) are normal during a `/ship` cycle on a project with sparse CI history. Capture each fix as its own commit with a message that names the flake and the cause (e.g., "fix TestSession_RecentOutput sleep timing on slower CI") so the rationale stays clear in history. Then re-run `/merge`.
 
 ---
 

--- a/agents/skills/ship/SKILL.md
+++ b/agents/skills/ship/SKILL.md
@@ -147,7 +147,7 @@ Invoke the `/merge` skill to land the branch into master.
 
 Handle merge script exit codes as documented in the `/merge` skill (conflicts, nothing to merge, review blocked, errors).
 
-**If CI fails on tests unrelated to your PR**, fix them inline as part of `/ship` rather than rebasing or treating the merge as blocked. Pre-existing flakes (timing-sensitive tests, data races on shared mutable state, environment-dependent assertions) are normal during a `/ship` cycle on a project with sparse CI history. Capture each fix as its own commit with a message that names the flake and the cause (e.g., "fix TestSession_RecentOutput sleep timing on slower CI") so the rationale stays clear in history. Then re-run `/merge`.
+**If CI fails on tests unrelated to your PR**, fix them inline as part of `/ship` rather than rebasing or treating the merge as blocked. Pre-existing flakes (timing-sensitive tests, data races on shared mutable state, environment-dependent assertions) are normal during a `/ship` cycle on a project with sparse CI history. Capture each fix as its own commit with a message that names the flake and the cause (e.g., "fix flaky-test sleep timing on slower CI" or "fix data race on shared buffer under -race") so the rationale stays clear in history. Then re-run `/merge`.
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation-only edits to two agent skills based on observations from a recent multi-feature PR review session.

**`/rereview`**
- Adds an "Auth-gate symmetry check" callout under the Security checklist — when reviewing destructive or configuration-mutating endpoints, enumerate every parallel CRUD group and flag any group with asymmetric auth gating.
- Adds an explicit per-reviewer 4 KB length budget at the top of the Output Format section to keep sub-agent reports from getting truncated when returned to the coordinator.

**`/ship`**
- Phase 1: clarifies that `/review` and `/rereview` are complementary (depth-first vs breadth-first) and Phase 1 should still run after a clean `/rereview`. Notes that Phase 2 acts on `/review`'s findings only.
- Phase 5: notes that pre-existing CI flakes unrelated to the PR should be fixed inline as separate commits during the ship cycle rather than treated as merge blockers.

## Test plan

- [x] go install ./...
- [x] revive -set_exit_status ./...
- [x] go test ./...
- [x] bash .github/skill-tests/run_all.sh
- [x] bash .github/lint-skills.sh

Co-Authored-By: Claude <noreply@anthropic.com>