### PR TITLE
Add /archive skill: end-of-session Argus task archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ dots docker stop-all     # Stop all Docker containers
 
 ## Agent Skills
 
-Dots includes 53 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
+Dots includes 54 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
 
 | Skill | Description |
 |-------|-------------|
@@ -115,6 +115,7 @@ Dots includes 53 reusable slash-command skills for AI coding agents, following t
 | `/loop` | Run a prompt on a recurring interval for polling, monitoring, and babysitting |
 | `/skill-usage` | Show skill usage statistics, charts, and suggestions for pruning unused skills |
 | `/wrapup` | End-of-session checklist that detects loose ends and routes to follow-up skills |
+| `/archive` | Archive the current Argus task at session end via the `argus` MCP tool |
 
 Skills use YAML frontmatter for metadata and dynamic context injection via shell commands. Some skills delegate to standalone bash scripts in `agents/skills/<name>/scripts/`. See `/write-skill` for the full authoring guide.
 
@@ -183,7 +184,7 @@ Run `dots install agents` to symlink them to `~/.claude/agents/`.
 ├── fonts/                     # Developer fonts
 │
 ├── agents/                    # Agent configuration
-│   ├── skills/                # 47 reusable skills (SKILL.md per skill)
+│   ├── skills/                # 54 reusable skills (SKILL.md per skill)
 │   └── custom/                # 3 custom agent types (.md per agent)
 │       └── tests/             # Skill test suite
 │

--- a/agents/skills/archive/SKILL.md
+++ b/agents/skills/archive/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: archive
+description: Archive the current Argus task so it moves to the Archive section of the task list. Use at the end of a session when the work is done.
+allowed-tools: mcp__argus__task_archive
+---
+
+# Archive Current Task
+
+Mark the Argus task owning the current worktree as archived. Archiving moves the task into the Archive section of the task list and clears its waiting-for-review flag.
+
+## Context
+
+- Current directory: !`pwd`
+
+## Your task
+
+Call the `mcp__argus__task_archive` MCP tool with the working directory from the Context block above as the `cwd` argument, and `archived: true`:
+
+```
+mcp__argus__task_archive(cwd: "<pwd from context>", archived: true)
+```
+
+Argus resolves the task from `cwd` by matching it against task worktree paths — the agent process does not know its own task ID, so `cwd` is the required hand-off.
+
+Do **not** pass `id` — the agent has no reliable way to know it.
+
+After the call, report the tool's response verbatim in one line. If the tool errors (e.g. "no task matches cwd"), show the error and stop; do not retry with guessed arguments.
+
+### Unarchiving
+
+If `$ARGUMENTS` is the literal word `undo`, call with `archived: false` instead. Otherwise always pass `archived: true` — toggling from an unknown prior state is surprising.


### PR DESCRIPTION
Promote the `/archive` skill from the Argus repo into the global dots
skill library. Calls the renamed `mcp__argus__task_archive` MCP tool
(introduced in argus PR #479) to mark the current task as archived,
resolving the task by `cwd`.

Notes:
- Source content was reviewed in argus PR #479; copied verbatim.
- Users must restart the argus daemon for the renamed `argus` MCP key
  (was `argus-kb`) to land in `~/.claude.json` before `/archive` works.
- README skill counts bumped (53 → 54; tree count corrected from stale
  47 → 54).

Co-Authored-By: Claude <noreply@anthropic.com>