### PR TITLE
/merge: probe allowed merge methods, fall back beyond squash

### DIFF
--- a/.github/skill-tests/test_merge.sh
+++ b/.github/skill-tests/test_merge.sh
@@ -194,14 +194,31 @@ test_detect_allowed_methods_fallback_when_probe_fails() {
   make_test_repo >/dev/null
 
   _source_merge
-  # Pointing at a nonexistent repo guarantees the gh api probe returns nothing,
-  # so detect_allowed_methods should fall back to "try every method".
-  REPO_SLUG="nonexistent-org-xyz/nonexistent-repo-12345"
+  # Stub gh to a no-op failure so the fallback path runs hermetically (no
+  # network, no auth state). detect_allowed_methods must default to all three
+  # methods in preference order.
+  gh() { return 1; }
+  REPO_SLUG="example-org/example-repo"
   detect_allowed_methods 2>/dev/null
+  unset -f gh
 
-  assert_contains "$ALLOWED_METHODS" "squash" "fallback should include squash"
-  assert_contains "$ALLOWED_METHODS" "rebase" "fallback should include rebase"
-  assert_contains "$ALLOWED_METHODS" "merge"  "fallback should include merge-commit"
+  assert_eq "${#ALLOWED_METHODS[@]}" "3" "fallback should list all 3 methods"
+  assert_eq "${ALLOWED_METHODS[*]}" "squash rebase merge" "fallback order should be squash → rebase → merge"
+}
+
+test_detect_allowed_methods_parses_probe() {
+  make_test_repo >/dev/null
+
+  _source_merge
+  # Stub gh to return TSV: squash=false, rebase=true, merge=false.
+  # detect_allowed_methods should pick only rebase.
+  gh() { printf 'false\ttrue\tfalse\n'; }
+  REPO_SLUG="example-org/rebase-only"
+  detect_allowed_methods 2>/dev/null
+  unset -f gh
+
+  assert_eq "${#ALLOWED_METHODS[@]}" "1" "should pick only the allowed method"
+  assert_eq "${ALLOWED_METHODS[0]}" "rebase" "should select rebase when only rebase is allowed"
 }
 
 test_detect_allowed_methods_requires_repo_slug() {

--- a/.github/skill-tests/test_merge.sh
+++ b/.github/skill-tests/test_merge.sh
@@ -156,4 +156,60 @@ test_summary_format() {
   assert_not_contains "$output" "~/.dots:" "should not show dots when empty"
 }
 
+test_summary_format_rebase_method() {
+  _source_merge
+  MERGE_STATUS="merged"
+  MERGE_METHOD="rebase"
+  PR_URL="https://github.com/test/repo/pull/2"
+  BRANCH="feature/rebase-only"
+  DEFAULT_BRANCH="main"
+  COMMIT_COUNT="2"
+  MERGE_COMMIT=""
+  DOTS_SYNCED=""
+
+  local output
+  output=$(print_summary)
+
+  assert_contains "$output" "method:   rebase" "should surface rebase method in summary"
+}
+
+test_summary_format_merge_commit_method() {
+  _source_merge
+  MERGE_STATUS="merged"
+  MERGE_METHOD="merge"
+  PR_URL="https://github.com/test/repo/pull/3"
+  BRANCH="feature/merge-only"
+  DEFAULT_BRANCH="main"
+  COMMIT_COUNT="4"
+  MERGE_COMMIT=""
+  DOTS_SYNCED=""
+
+  local output
+  output=$(print_summary)
+
+  assert_contains "$output" "method:   merge" "should surface merge-commit method in summary"
+}
+
+test_detect_allowed_methods_fallback_when_probe_fails() {
+  make_test_repo >/dev/null
+
+  _source_merge
+  # Pointing at a nonexistent repo guarantees the gh api probe returns nothing,
+  # so detect_allowed_methods should fall back to "try every method".
+  REPO_SLUG="nonexistent-org-xyz/nonexistent-repo-12345"
+  detect_allowed_methods 2>/dev/null
+
+  assert_contains "$ALLOWED_METHODS" "squash" "fallback should include squash"
+  assert_contains "$ALLOWED_METHODS" "rebase" "fallback should include rebase"
+  assert_contains "$ALLOWED_METHODS" "merge"  "fallback should include merge-commit"
+}
+
+test_detect_allowed_methods_requires_repo_slug() {
+  _source_merge
+  REPO_SLUG=""
+  capture detect_allowed_methods
+  assert_eq "$_CAPTURED_EXIT" "1" "should die if REPO_SLUG is unset"
+  assert_contains "$_CAPTURED" "REPO_SLUG not set" "should report missing REPO_SLUG"
+}
+
 run_tests

--- a/agents/skills/merge/scripts/merge.sh
+++ b/agents/skills/merge/scripts/merge.sh
@@ -57,6 +57,12 @@ determine_target() {
 detect_default_branch() {
   REPO_SLUG=$(git remote get-url "$TARGET" | sed 's|.*github.com[:/]||;s|\.git$||')
 
+  # Reject malformed slugs early — anything other than owner/repo (allowing
+  # standard GitHub characters) would corrupt later `gh api` and `gh pr merge`
+  # calls, since REPO_SLUG is interpolated into URL/argv positions.
+  [[ "$REPO_SLUG" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]] \
+    || die 1 "Could not parse owner/repo from ${TARGET} remote URL (got: '${REPO_SLUG}')"
+
   # Primary: ask GitHub API for the actual default branch
   local api_default
   api_default=$(gh api "repos/${REPO_SLUG}" --jq '.default_branch' 2>/dev/null || echo "")
@@ -210,6 +216,9 @@ _gh_merge() {
   err_file=$(mktemp)
   if gh pr merge "${args[@]}" 2>"$err_file"; then
     rc=0
+    # --admin bypasses branch protection (required reviewers, status checks).
+    # Make the bypass visible so it never happens silently.
+    [[ "$extra" == "--admin" ]] && info "WARNING: merged via --admin (branch protection bypassed)"
   else
     rc=$?
     LAST_GH_ERR=$(cat "$err_file")

--- a/agents/skills/merge/scripts/merge.sh
+++ b/agents/skills/merge/scripts/merge.sh
@@ -22,6 +22,7 @@ COMMIT_COUNT=""
 PR_NUMBER=""
 PR_URL=""
 REPO_SLUG=""
+ALLOWED_METHODS=""
 MERGE_METHOD=""
 MERGE_STATUS="merged"
 MERGE_COMMIT=""
@@ -152,57 +153,128 @@ check_pr_state() {
   fi
 }
 
+detect_allowed_methods() {
+  [[ -z "$REPO_SLUG" ]] && die 1 "REPO_SLUG not set — detect_default_branch must run first"
+
+  # Probe repo settings: each .allow_<method>_merge field is true/false.
+  # Preference order: squash → rebase → merge-commit.
+  local json
+  json=$(gh api "repos/${REPO_SLUG}" \
+    --jq '{squash:.allow_squash_merge,rebase:.allow_rebase_merge,merge:.allow_merge_commit}' \
+    2>/dev/null || echo "")
+
+  local list=""
+  if [[ -n "$json" ]]; then
+    local squash rebase merge_commit
+    squash=$(echo "$json" | jq -r '.squash')
+    rebase=$(echo "$json" | jq -r '.rebase')
+    merge_commit=$(echo "$json" | jq -r '.merge')
+    [[ "$squash"       == "true" ]] && list="${list}squash "
+    [[ "$rebase"       == "true" ]] && list="${list}rebase "
+    [[ "$merge_commit" == "true" ]] && list="${list}merge "
+  fi
+
+  if [[ -z "$list" ]]; then
+    # Probe failed or returned nothing — try every method in preference order.
+    ALLOWED_METHODS="squash rebase merge"
+    info "Allowed merge methods unknown; will try: ${ALLOWED_METHODS}"
+  else
+    ALLOWED_METHODS="${list% }"
+    info "Allowed merge methods: ${ALLOWED_METHODS}"
+  fi
+}
+
+_gh_merge() {
+  # Run `gh pr merge` for the given method, optionally with --admin or --auto.
+  # Returns gh's exit code. --subject/--body apply to squash and merge-commit
+  # only; rebase keeps the original commits and rejects those flags.
+  local method="$1" extra="$2" title="$3" body="$4"
+
+  local flag
+  case "$method" in
+    squash) flag="--squash" ;;
+    rebase) flag="--rebase" ;;
+    merge)  flag="--merge"  ;;
+    *) return 99 ;;
+  esac
+
+  if [[ "$method" == "rebase" ]]; then
+    if [[ -n "$extra" ]]; then
+      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" "$extra" 2>/dev/null
+    else
+      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" 2>/dev/null
+    fi
+  else
+    if [[ -n "$extra" ]]; then
+      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" "$extra" --subject "$title" --body "$body" 2>/dev/null
+    else
+      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" --subject "$title" --body "$body" 2>/dev/null
+    fi
+  fi
+}
+
 do_merge() {
   local title="$1" body="$2"
+  local method
 
   info "Merging PR #${PR_NUMBER}..."
 
-  # If review is blocking the merge, skip immediate merge and try admin/auto-merge
+  # If review is blocking the merge, skip plain merge and try admin/auto.
   if [[ "$PR_REVIEW_DECISION" == "REVIEW_REQUIRED" || "$PR_REVIEW_DECISION" == "CHANGES_REQUESTED" ]]; then
     local reason="review required"
     [[ "$PR_REVIEW_DECISION" == "CHANGES_REQUESTED" ]] && reason="changes requested"
     info "PR blocked (${reason}) — trying admin merge..."
 
-    if gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" --squash --admin --subject "$title" --body "$body" 2>/dev/null; then
-      MERGE_METHOD="squash (admin)"
-      return 0
-    fi
+    for method in $ALLOWED_METHODS; do
+      if _gh_merge "$method" "--admin" "$title" "$body"; then
+        MERGE_METHOD="${method} (admin)"
+        return 0
+      fi
+    done
 
     info "Admin merge failed, enabling auto-merge..."
 
-    if gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" --squash --auto --subject "$title" --body "$body" 2>/dev/null; then
-      MERGE_METHOD="squash (auto-merge)"
-      MERGE_STATUS="auto-merge enabled (${reason})"
-      return 0
-    fi
+    for method in $ALLOWED_METHODS; do
+      if _gh_merge "$method" "--auto" "$title" "$body"; then
+        MERGE_METHOD="${method} (auto-merge)"
+        MERGE_STATUS="auto-merge enabled (${reason})"
+        return 0
+      fi
+    done
 
     die 4 "PR #${PR_NUMBER} is blocked (${reason}) and auto-merge is not available on this repository"
   fi
 
-  # Attempt 1: squash merge
-  if gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" --squash --subject "$title" --body "$body" 2>/dev/null; then
-    MERGE_METHOD="squash"
-    return 0
-  fi
+  # Tier 1: plain merge with each allowed method (preferred order).
+  for method in $ALLOWED_METHODS; do
+    if _gh_merge "$method" "" "$title" "$body"; then
+      MERGE_METHOD="$method"
+      return 0
+    fi
+  done
 
-  info "Squash merge failed, trying admin merge..."
+  info "Plain merge failed, trying admin merge..."
 
-  # Attempt 2: admin squash (bypasses branch protection)
-  if gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" --squash --admin --subject "$title" --body "$body" 2>/dev/null; then
-    MERGE_METHOD="squash (admin)"
-    return 0
-  fi
+  # Tier 2: --admin (bypasses branch protection if the user has admin).
+  for method in $ALLOWED_METHODS; do
+    if _gh_merge "$method" "--admin" "$title" "$body"; then
+      MERGE_METHOD="${method} (admin)"
+      return 0
+    fi
+  done
 
   info "Admin merge failed, trying auto-merge..."
 
-  # Attempt 3: squash with auto-merge
-  if gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" --squash --auto --subject "$title" --body "$body" 2>/dev/null; then
-    MERGE_METHOD="squash (auto-merge)"
-    MERGE_STATUS="auto-merge enabled"
-    return 0
-  fi
+  # Tier 3: --auto (queues the merge for when checks pass).
+  for method in $ALLOWED_METHODS; do
+    if _gh_merge "$method" "--auto" "$title" "$body"; then
+      MERGE_METHOD="${method} (auto-merge)"
+      MERGE_STATUS="auto-merge enabled"
+      return 0
+    fi
+  done
 
-  die 1 "All squash merge strategies failed for PR #${PR_NUMBER}"
+  die 1 "All merge strategies failed for PR #${PR_NUMBER} (tried: ${ALLOWED_METHODS})"
 }
 
 fetch_merge_commit() {
@@ -305,6 +377,7 @@ ${COAUTHOR}"
   do_push
   ensure_pr "$title" "$body"
   check_pr_state
+  detect_allowed_methods
   do_merge "$title" "$body"
   fetch_merge_commit       # must precede update_local_master (uses GitHub API, not local state)
   update_local_master

--- a/agents/skills/merge/scripts/merge.sh
+++ b/agents/skills/merge/scripts/merge.sh
@@ -22,13 +22,14 @@ COMMIT_COUNT=""
 PR_NUMBER=""
 PR_URL=""
 REPO_SLUG=""
-ALLOWED_METHODS=""
+ALLOWED_METHODS=()
 MERGE_METHOD=""
 MERGE_STATUS="merged"
 MERGE_COMMIT=""
 DOTS_SYNCED=""
 PR_MERGE_STATE=""
 PR_REVIEW_DECISION=""
+LAST_GH_ERR=""
 
 # --- Helpers ---
 
@@ -139,6 +140,9 @@ ensure_pr() {
     PR_URL=$(gh pr create --base "$DEFAULT_BRANCH" --head "$BRANCH" --title "$title" --body "$body" 2>&1 | grep -o 'https://github.com/[^ ]*' | head -1)
     PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]*$')
   fi
+  # Guard against silent fall-through to gh's "current branch" PR detection if
+  # parsing failed — every later gh call would otherwise target the wrong PR.
+  [[ -z "$PR_NUMBER" ]] && die 1 "Could not determine PR number (PR_URL=${PR_URL:-<empty>})"
   info "PR: ${PR_URL}"
 }
 
@@ -156,38 +160,38 @@ check_pr_state() {
 detect_allowed_methods() {
   [[ -z "$REPO_SLUG" ]] && die 1 "REPO_SLUG not set — detect_default_branch must run first"
 
-  # Probe repo settings: each .allow_<method>_merge field is true/false.
+  # Probe repo settings as TSV (squash<TAB>rebase<TAB>merge), each "true" or "false".
   # Preference order: squash → rebase → merge-commit.
-  local json
-  json=$(gh api "repos/${REPO_SLUG}" \
-    --jq '{squash:.allow_squash_merge,rebase:.allow_rebase_merge,merge:.allow_merge_commit}' \
+  local probe
+  probe=$(gh api "repos/${REPO_SLUG}" \
+    --jq '[.allow_squash_merge,.allow_rebase_merge,.allow_merge_commit] | @tsv' \
     2>/dev/null || echo "")
 
-  local list=""
-  if [[ -n "$json" ]]; then
+  ALLOWED_METHODS=()
+  if [[ -n "$probe" ]]; then
     local squash rebase merge_commit
-    squash=$(echo "$json" | jq -r '.squash')
-    rebase=$(echo "$json" | jq -r '.rebase')
-    merge_commit=$(echo "$json" | jq -r '.merge')
-    [[ "$squash"       == "true" ]] && list="${list}squash "
-    [[ "$rebase"       == "true" ]] && list="${list}rebase "
-    [[ "$merge_commit" == "true" ]] && list="${list}merge "
+    IFS=$'\t' read -r squash rebase merge_commit <<<"$probe"
+    [[ "$squash"       == "true" ]] && ALLOWED_METHODS+=("squash")
+    [[ "$rebase"       == "true" ]] && ALLOWED_METHODS+=("rebase")
+    [[ "$merge_commit" == "true" ]] && ALLOWED_METHODS+=("merge")
   fi
 
-  if [[ -z "$list" ]]; then
+  if [[ ${#ALLOWED_METHODS[@]} -eq 0 ]]; then
     # Probe failed or returned nothing — try every method in preference order.
-    ALLOWED_METHODS="squash rebase merge"
-    info "Allowed merge methods unknown; will try: ${ALLOWED_METHODS}"
+    ALLOWED_METHODS=(squash rebase merge)
+    info "Allowed merge methods unknown; will try: ${ALLOWED_METHODS[*]}"
   else
-    ALLOWED_METHODS="${list% }"
-    info "Allowed merge methods: ${ALLOWED_METHODS}"
+    info "Allowed merge methods: ${ALLOWED_METHODS[*]}"
   fi
 }
 
 _gh_merge() {
   # Run `gh pr merge` for the given method, optionally with --admin or --auto.
-  # Returns gh's exit code. --subject/--body apply to squash and merge-commit
-  # only; rebase keeps the original commits and rejects those flags.
+  # Returns gh's exit code; on failure, stderr is captured into LAST_GH_ERR so
+  # the terminal die can surface the underlying error instead of silently
+  # exhausting all methods × tiers.
+  # --subject/--body apply to squash and merge-commit only; rebase keeps the
+  # original commits and rejects those flags.
   local method="$1" extra="$2" title="$3" body="$4"
 
   local flag
@@ -198,19 +202,20 @@ _gh_merge() {
     *) return 99 ;;
   esac
 
-  if [[ "$method" == "rebase" ]]; then
-    if [[ -n "$extra" ]]; then
-      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" "$extra" 2>/dev/null
-    else
-      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" 2>/dev/null
-    fi
+  local args=("$PR_NUMBER" --repo "$REPO_SLUG" "$flag")
+  [[ -n "$extra" ]] && args+=("$extra")
+  [[ "$method" != "rebase" ]] && args+=(--subject "$title" --body "$body")
+
+  local err_file rc
+  err_file=$(mktemp)
+  if gh pr merge "${args[@]}" 2>"$err_file"; then
+    rc=0
   else
-    if [[ -n "$extra" ]]; then
-      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" "$extra" --subject "$title" --body "$body" 2>/dev/null
-    else
-      gh pr merge "$PR_NUMBER" --repo "$REPO_SLUG" "$flag" --subject "$title" --body "$body" 2>/dev/null
-    fi
+    rc=$?
+    LAST_GH_ERR=$(cat "$err_file")
   fi
+  rm -f "$err_file"
+  return "$rc"
 }
 
 do_merge() {
@@ -225,7 +230,7 @@ do_merge() {
     [[ "$PR_REVIEW_DECISION" == "CHANGES_REQUESTED" ]] && reason="changes requested"
     info "PR blocked (${reason}) — trying admin merge..."
 
-    for method in $ALLOWED_METHODS; do
+    for method in "${ALLOWED_METHODS[@]}"; do
       if _gh_merge "$method" "--admin" "$title" "$body"; then
         MERGE_METHOD="${method} (admin)"
         return 0
@@ -234,7 +239,7 @@ do_merge() {
 
     info "Admin merge failed, enabling auto-merge..."
 
-    for method in $ALLOWED_METHODS; do
+    for method in "${ALLOWED_METHODS[@]}"; do
       if _gh_merge "$method" "--auto" "$title" "$body"; then
         MERGE_METHOD="${method} (auto-merge)"
         MERGE_STATUS="auto-merge enabled (${reason})"
@@ -242,11 +247,12 @@ do_merge() {
       fi
     done
 
-    die 4 "PR #${PR_NUMBER} is blocked (${reason}) and auto-merge is not available on this repository"
+    die 4 "PR #${PR_NUMBER} is blocked (${reason}) and auto-merge is not available on this repository${LAST_GH_ERR:+
+  Last gh error: ${LAST_GH_ERR}}"
   fi
 
   # Tier 1: plain merge with each allowed method (preferred order).
-  for method in $ALLOWED_METHODS; do
+  for method in "${ALLOWED_METHODS[@]}"; do
     if _gh_merge "$method" "" "$title" "$body"; then
       MERGE_METHOD="$method"
       return 0
@@ -256,7 +262,7 @@ do_merge() {
   info "Plain merge failed, trying admin merge..."
 
   # Tier 2: --admin (bypasses branch protection if the user has admin).
-  for method in $ALLOWED_METHODS; do
+  for method in "${ALLOWED_METHODS[@]}"; do
     if _gh_merge "$method" "--admin" "$title" "$body"; then
       MERGE_METHOD="${method} (admin)"
       return 0
@@ -266,7 +272,7 @@ do_merge() {
   info "Admin merge failed, trying auto-merge..."
 
   # Tier 3: --auto (queues the merge for when checks pass).
-  for method in $ALLOWED_METHODS; do
+  for method in "${ALLOWED_METHODS[@]}"; do
     if _gh_merge "$method" "--auto" "$title" "$body"; then
       MERGE_METHOD="${method} (auto-merge)"
       MERGE_STATUS="auto-merge enabled"
@@ -274,7 +280,8 @@ do_merge() {
     fi
   done
 
-  die 1 "All merge strategies failed for PR #${PR_NUMBER} (tried: ${ALLOWED_METHODS})"
+  die 1 "All merge strategies failed for PR #${PR_NUMBER} (tried: ${ALLOWED_METHODS[*]})${LAST_GH_ERR:+
+  Last gh error: ${LAST_GH_ERR}}"
 }
 
 fetch_merge_commit() {
@@ -346,7 +353,7 @@ main() {
   while [[ "${1:-}" == --* ]]; do
     case "$1" in
       --skip-rebase) skip_rebase=true; shift ;;
-      --squash)      shift ;;  # no-op: squash is already the default
+      --squash)      shift ;;  # no-op: squash is the preferred method when allowed
       *)             die 1 "Unknown flag: $1 — usage: merge.sh [--skip-rebase] [--squash] \"<title>\" \"<body>\"" ;;
     esac
   done


### PR DESCRIPTION
Previously merge.sh tried squash → squash --admin → squash --auto and died if all three failed, even when the repo had squash merges disabled (e.g. rebase-only repos). Now it probes the repo via `gh api repos/<slug>` for `allow_squash_merge` / `allow_rebase_merge` / `allow_merge_commit`, builds an ordered strategy list (squash → rebase → merge), and iterates each allowed method through the same plain → --admin → --auto tiers. Falls back to trying every method when the probe returns nothing.

Also widens `MERGE_METHOD`'s value space — the summary's `method:` line now reflects rebase / merge as well as squash.

## Hardening from review

- `ensure_pr` now dies on empty `PR_NUMBER` (parsed from `gh pr create` URL) instead of silently letting later `gh pr merge` calls fall through to gh's "current branch" detection.
- `_gh_merge` captures stderr per attempt into `LAST_GH_ERR`; the terminal `die` surfaces it so transient/auth/network failures aren't indistinguishable from "method not allowed" after up to 9 attempts.
- `ALLOWED_METHODS` is a typed bash array (no hidden splitting contract).
- `_gh_merge` collapses 4-branch (rebase × extra-flag) duplication into one `args=()` construction.
- `detect_default_branch` rejects malformed `REPO_SLUG` — anything other than `owner/repo` fails fast instead of corrupting later API calls.
- `_gh_merge` logs a WARNING when `--admin` succeeds, since `--admin` bypasses branch protection (required reviewers, status checks).

## Tests

Added 5 new tests covering the new method values in summary output, the probe parsing path with a stubbed `gh`, the fallback path with a stubbed-failing `gh`, and the `REPO_SLUG` precondition guard. The fallback test no longer makes a real network call.

Co-Authored-By: Claude <noreply@anthropic.com>