### PR TITLE
Improve /cross-agent, /merge, /pr from session feedback

### DIFF
--- a/.github/skill-tests/test_merge.sh
+++ b/.github/skill-tests/test_merge.sh
@@ -115,6 +115,51 @@ test_squash_flag_accepted() {
   assert_not_contains "$_CAPTURED" "Unknown flag" "should accept --squash without error"
 }
 
+test_method_rebase_flag_accepted() {
+  make_test_repo >/dev/null
+  add_test_remote "origin" >/dev/null
+  git checkout -q -b feature/test
+  git commit -q --allow-empty -m "work"
+
+  # --rebase is the regression case for the bash 3.2 empty-array crash
+  capture bash "$MERGE" --rebase "test title" "test body"
+  assert_not_contains "$_CAPTURED" "Unknown flag" "should accept --rebase without error"
+  assert_not_contains "$_CAPTURED" "unbound variable" "should not crash on empty subject_flags array under set -u"
+}
+
+test_method_merge_flag_accepted() {
+  make_test_repo >/dev/null
+  add_test_remote "origin" >/dev/null
+  git checkout -q -b feature/test
+  git commit -q --allow-empty -m "work"
+
+  capture bash "$MERGE" --merge "test title" "test body"
+  assert_not_contains "$_CAPTURED" "Unknown flag" "should accept --merge without error"
+  assert_not_contains "$_CAPTURED" "unbound variable" "should not crash under set -u"
+}
+
+test_method_long_flag_accepted() {
+  make_test_repo >/dev/null
+  add_test_remote "origin" >/dev/null
+  git checkout -q -b feature/test
+  git commit -q --allow-empty -m "work"
+
+  capture bash "$MERGE" --method rebase "test title" "test body"
+  assert_not_contains "$_CAPTURED" "Unknown flag" "should accept --method rebase"
+  assert_not_contains "$_CAPTURED" "unbound variable" "should not crash under set -u"
+}
+
+test_method_invalid_value_rejected() {
+  make_test_repo >/dev/null
+  add_test_remote "origin" >/dev/null
+  git checkout -q -b feature/test
+  git commit -q --allow-empty -m "work"
+
+  capture bash "$MERGE" --method bogus "test title" "test body"
+  assert_eq "$_CAPTURED_EXIT" "1" "should exit 1 on invalid --method value"
+  assert_contains "$_CAPTURED" "Invalid --method" "should report the invalid value"
+}
+
 test_unknown_flag_rejected() {
   make_test_repo >/dev/null
   add_test_remote "origin" >/dev/null

--- a/agents/skills/cross-agent/SKILL.md
+++ b/agents/skills/cross-agent/SKILL.md
@@ -86,7 +86,7 @@ State: [GREENFIELD/CLAUDE-ONLY/PARTIAL/COMPLETE]
 ### Per-Subtree Migration (omit this section if no subtree CLAUDE.md / AGENTS.md found)
 | Subtree | State | Action |
 |---|---|---|
-| `nucleus/`        | CLAUDE-only        | git mv CLAUDE.md AGENTS.md; symlink CLAUDE.md → AGENTS.md |
+| `engine/`         | CLAUDE-only        | git mv CLAUDE.md AGENTS.md; symlink CLAUDE.md → AGENTS.md |
 | `services/admin/` | Both, divergent    | merge CLAUDE.md + AGENTS.md → AGENTS.md (verify both); symlink CLAUDE.md |
 | `services/api/`   | Both, identical    | rm CLAUDE.md; symlink CLAUDE.md → AGENTS.md |
 | `services/web/`   | AGENTS-only        | symlink CLAUDE.md → AGENTS.md |
@@ -134,7 +134,7 @@ For each existing canonical skill:
 
 ### Step 4.5: Apply Per-Subtree Migration
 
-If the Step 1 subtree scan found any subtree-level CLAUDE.md / AGENTS.md files, walk each entry from the approved per-subtree table and apply the action. **Use `git mv` for tracked files** so history is preserved. Always create a **relative** symlink within the subtree (e.g., `cd nucleus/ && ln -s AGENTS.md CLAUDE.md`).
+If the Step 1 subtree scan found any subtree-level CLAUDE.md / AGENTS.md files, walk each entry from the approved per-subtree table and apply the action. **Use `git mv` for tracked files** so history is preserved. Always create a **relative** symlink within the subtree (e.g., `cd engine/ && ln -s AGENTS.md CLAUDE.md`).
 
 Per-state actions:
 
@@ -215,7 +215,7 @@ Before committing the merged AGENTS.md and replacing CLAUDE.md with a symlink:
 3. If anything is missing, re-merge to include it (or escalate to the user with the specific snippets that were dropped).
 4. Only after the grep verification passes, replace CLAUDE.md with the symlink.
 
-Apply the same validation when merging subtree CLAUDE.md / AGENTS.md pairs (Step 4 / Step 1 subtree scan classified as "Both, divergent").
+Apply the same validation when merging subtree CLAUDE.md / AGENTS.md pairs (Step 4.5 acting on a Step 1 subtree scan classified as "Both, divergent"). Step 4.5 explicitly delegates the divergent-merge rules to this section, so the `grep -F` snippet check applies identically there.
 
 ### Step 8: Generate Copilot Instructions
 

--- a/agents/skills/cross-agent/SKILL.md
+++ b/agents/skills/cross-agent/SKILL.md
@@ -21,6 +21,8 @@ Migrate a repository's skills to the Agent Skills open standard so they work acr
 - CLAUDE.md type: !`file CLAUDE.md 2>/dev/null | head -1`
 - claude.md (lowercase) exists: !`find . -maxdepth 1 -type f 2>/dev/null | grep '/claude\.md$' | head -1`
 - Copilot instructions: !`find .github -maxdepth 1 -name copilot-instructions.md 2>/dev/null | head -1`
+- Subtree CLAUDE.md files: !`find . -mindepth 2 -maxdepth 4 -name CLAUDE.md -not -path './.git/*' 2>/dev/null | head -20`
+- Subtree AGENTS.md files: !`find . -mindepth 2 -maxdepth 4 -name AGENTS.md -not -path './.git/*' 2>/dev/null | head -20`
 - Git root: !`git rev-parse --show-toplevel 2>/dev/null | head -1`
 
 ## Instructions
@@ -47,6 +49,18 @@ Classify the repo:
 - **PARTIAL**: `.agents/skills/` exists but missing infrastructure (no AGENTS.md, no Copilot instructions, no sync scripts).
 - **COMPLETE**: `.agents/skills/` exists with all infrastructure. Run validation only.
 
+#### Subtree scan (monorepos)
+
+Also scan for subtree-level `CLAUDE.md` / `AGENTS.md` files (any depth ≥ 2 inside the repo, excluding `.git`). For each subtree directory, classify:
+
+- **CLAUDE-only** — only `CLAUDE.md` exists → `git mv` to `AGENTS.md` and add `CLAUDE.md` symlink
+- **AGENTS-only** — only `AGENTS.md` exists → add `CLAUDE.md` symlink
+- **Both, identical** — `cmp -s CLAUDE.md AGENTS.md` returns 0 → drop `CLAUDE.md`, replace with symlink
+- **Both, divergent** — content differs → **merge required** (see Step 7 validation rules)
+- **Symlink already** — `CLAUDE.md` is a symlink to `AGENTS.md` → skip
+
+Treat subtrees as a first-class migration target, not an "out of scope" observation. The user expects `cross-agent` to migrate the entire monorepo in one pass.
+
 ### Step 2: Present Migration Plan
 
 Show the user:
@@ -68,10 +82,19 @@ State: [GREENFIELD/CLAUDE-ONLY/PARTIAL/COMPLETE]
 - [ ] CLAUDE.md symlink to AGENTS.md
 - [ ] .claude/skills symlink to .agents/skills
 - [ ] .github/copilot-instructions.md
+
+### Per-Subtree Migration (omit this section if no subtree CLAUDE.md / AGENTS.md found)
+| Subtree | State | Action |
+|---|---|---|
+| `nucleus/`        | CLAUDE-only        | git mv CLAUDE.md AGENTS.md; symlink CLAUDE.md → AGENTS.md |
+| `services/admin/` | Both, divergent    | merge CLAUDE.md + AGENTS.md → AGENTS.md (verify both); symlink CLAUDE.md |
+| `services/api/`   | Both, identical    | rm CLAUDE.md; symlink CLAUDE.md → AGENTS.md |
+| `services/web/`   | AGENTS-only        | symlink CLAUDE.md → AGENTS.md |
+
 Proceed? (waiting for confirmation)
 ```
 
-Wait for confirmation before making changes.
+Wait for confirmation before making changes. The subtree table must show the **action** per subtree, not a passive observation. The user should be able to approve subtree migration in one step alongside the root migration.
 
 ### Step 3: Create Directory Structure
 
@@ -108,6 +131,20 @@ For each existing canonical skill:
 1. Read `SKILL.md` and verify `name:` field exists in frontmatter
 2. If missing, add it
 3. Do not modify the body
+
+### Step 4.5: Apply Per-Subtree Migration
+
+If the Step 1 subtree scan found any subtree-level CLAUDE.md / AGENTS.md files, walk each entry from the approved per-subtree table and apply the action. **Use `git mv` for tracked files** so history is preserved. Always create a **relative** symlink within the subtree (e.g., `cd nucleus/ && ln -s AGENTS.md CLAUDE.md`).
+
+Per-state actions:
+
+- **CLAUDE-only** — `git mv <subtree>/CLAUDE.md <subtree>/AGENTS.md`, then create symlink `<subtree>/CLAUDE.md → AGENTS.md`.
+- **AGENTS-only** — create symlink `<subtree>/CLAUDE.md → AGENTS.md`.
+- **Both, identical** — `git rm <subtree>/CLAUDE.md`, then create symlink `<subtree>/CLAUDE.md → AGENTS.md`.
+- **Both, divergent** — merge both into `<subtree>/AGENTS.md` (apply the Step 7 "Validation: divergent-content merge" rules), then `git rm <subtree>/CLAUDE.md` and create symlink `<subtree>/CLAUDE.md → AGENTS.md`.
+- **Symlink already** — verify it points to `AGENTS.md`; otherwise repair it.
+
+After processing all subtrees, sanity-check that every former CLAUDE.md location now resolves to its AGENTS.md sibling: `find . -name CLAUDE.md -not -path './.git/*' -exec test -L {} \; -exec readlink {} \; -print`.
 
 ### Step 5: Set Up Agent Discovery Symlinks
 
@@ -167,6 +204,19 @@ The goal is for `CLAUDE.md` to be a symlink to `AGENTS.md` so both Claude Code a
 3. Replace CLAUDE.md with a symlink to AGENTS.md
 4. Report what was merged so the user can review
 
+#### Validation: divergent-content merge
+
+When **both** CLAUDE.md and AGENTS.md exist with different content (not just one missing), the merge MUST preserve the substantive content of both files. Naive section-level appending can silently drop content if a section header matches but the body diverges (e.g., one file says `try devbox first → fallback to bundle exec`, the other just says `bundle exec rubocop`).
+
+Before committing the merged AGENTS.md and replacing CLAUDE.md with a symlink:
+
+1. Extract non-trivial content lines from each source file. A useful heuristic: every header (lines starting with `#`), every fenced code block, and every sentence longer than ~30 characters that isn't pure boilerplate.
+2. Run `grep -F` for each extracted snippet against the merged AGENTS.md. Any snippet that does not appear in the merged file indicates content was dropped.
+3. If anything is missing, re-merge to include it (or escalate to the user with the specific snippets that were dropped).
+4. Only after the grep verification passes, replace CLAUDE.md with the symlink.
+
+Apply the same validation when merging subtree CLAUDE.md / AGENTS.md pairs (Step 4 / Step 1 subtree scan classified as "Both, divergent").
+
 ### Step 8: Generate Copilot Instructions
 
 Create `.github/copilot-instructions.md` if it does not exist:
@@ -205,6 +255,8 @@ Verify the setup by checking:
 4. `CLAUDE.md` is a symlink to `AGENTS.md`
 5. `.github/copilot-instructions.md` exists
 6. No lowercase `claude.md` exists
+7. **Subtrees:** every subtree `CLAUDE.md` (any depth ≥ 2) is a symlink resolving to a sibling `AGENTS.md`. Run: `find . -name CLAUDE.md -not -path './.git/*' -not -path './CLAUDE.md'` and verify each is `-L` (symlink) with `readlink` returning `AGENTS.md`.
+8. **Divergent merges:** for each subtree where Step 1 classified as "Both, divergent", confirm the post-merge `grep -F` snippet check (Step 7 validation) was applied. If unsure, re-run the grep against the source content captured before the merge.
 
 Report results. If any checks fail, explain what needs fixing and offer to fix it.
 

--- a/agents/skills/merge/SKILL.md
+++ b/agents/skills/merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge
-allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git rebase:*), Bash(git checkout:*), Bash(bash ~/.claude/skills/merge/scripts/merge.sh:*), Bash(bash agents/skills/merge/scripts/merge.sh:*)
+allowed-tools: Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git rebase:*), Bash(git checkout:*), Bash(git reset:*), Bash(bash ~/.claude/skills/merge/scripts/merge.sh:*), Bash(bash agents/skills/merge/scripts/merge.sh:*)
 description: Merge current branch to the default branch via GitHub PR merge. Use when ready to merge a PR or land a branch.
 ---
 
@@ -73,10 +73,20 @@ Resolve the script path — use the first that exists:
 2. `agents/skills/merge/scripts/merge.sh` (repo-relative, for development/workspaces)
 
 ```
-bash <script-path> "<title>" "<body>"
+bash <script-path> [--method <squash|merge|rebase>] "<title>" "<body>"
 ```
 
-Handle the exit code:
+#### Choosing a merge method
+
+The script defaults to **squash** (collapses all commits into one). Pick a different method when squash would lose intentional structure:
+
+- `--method squash` (default) — single commit, ideal for a stream of WIP commits.
+- `--method merge` (alias `--merge`) — preserves all commits via a merge commit. Use when each commit is independently meaningful and you want to keep the merge boundary visible on master.
+- `--method rebase` (alias `--rebase`) — preserves all commits linearly via fast-forward / rebase. **Use this when the user has deliberately split work into multiple commits** (e.g., the user ran `/squash` to condense 7 commits into 2 separate logical commits, and wants both on master). A naive squash merge here would silently undo that intent.
+
+Heuristic: if the branch has more than one commit AND the commit messages look distinct rather than incremental ("WIP", "fix typo"), confirm with the user before using the default squash. The deliberate-split case is common after `/squash`.
+
+#### Handle the exit code
 
 - **Exit 0** — Show the output block verbatim as your final response. Do not add commentary.
 - **Exit 2 (rebase conflict)** — Resolve conflicts:
@@ -85,8 +95,18 @@ Handle the exit code:
   3. `git add` resolved files
   4. `git rebase --continue`
   5. Repeat if more conflicts
-  6. Re-run: `bash <script-path> --skip-rebase "<title>" "<body>"`
+  6. Re-run: `bash <script-path> --skip-rebase [--method <method>] "<title>" "<body>"`
   7. Show the output block verbatim
+
+  **Special case: "distinct types" conflicts.** If the rebase reports conflicts because the branch converted regular files to symlinks (or vice versa) while master independently edited those same files, do NOT naively resolve with `--theirs` or `--ours`. Both sides "win" — the branch's symlink target was sourced from old master content, so keeping the branch's version silently loses master's content updates.
+
+  Recovery pattern:
+  1. `git rebase --abort`.
+  2. Drop the symlink-conversion commit from the branch (e.g., `git rebase -i master` and drop it, or `git reset --soft <sha-before-symlink-commit>` then re-stage selectively).
+  3. Rebase the remaining commits onto master cleanly.
+  4. Rebuild the symlink-conversion commit fresh against current master — re-source the symlink target's content from the *current* master file, not from the original AGENTS.md content captured on the branch.
+  5. Re-run the merge script with `--skip-rebase`.
+
 - **Exit 3** — Tell the user: "Nothing to merge — branch has no commits ahead of the default branch."
 - **Exit 4 (review blocked)** — The PR requires review and auto-merge is not available. Tell the user: "PR requires an approving review before it can merge. Auto-merge is not enabled on this repository — ask a reviewer to approve, then re-run /merge."
 - **Exit 1** — Report the error from stderr.

--- a/agents/skills/merge/scripts/merge.sh
+++ b/agents/skills/merge/scripts/merge.sh
@@ -3,7 +3,13 @@ set -euo pipefail
 
 # merge.sh — Merge current branch to the default branch via GitHub PR
 #
-# Usage: merge.sh [--skip-rebase] [--squash] "<title>" "<body>"
+# Usage: merge.sh [--skip-rebase] [--method <squash|merge|rebase>] [--squash|--merge|--rebase] "<title>" "<body>"
+#
+# Without an explicit method, merge.sh probes the repo's allowed methods and
+# tries them in preference order (squash → rebase → merge). Pass --method (or
+# the matching shorthand) to force a single method — useful when the user
+# deliberately split a branch into multiple commits and wants `gh pr merge
+# --rebase` to preserve them on master, even on a repo that allows squash.
 #
 # Exit codes:
 #   0 — success (merge completed or auto-merge enabled)
@@ -30,6 +36,7 @@ DOTS_SYNCED=""
 PR_MERGE_STATE=""
 PR_REVIEW_DECISION=""
 LAST_GH_ERR=""
+MERGE_METHOD_FLAG=""  # input flag (squash|merge|rebase|""); narrows ALLOWED_METHODS when set
 
 # --- Helpers ---
 
@@ -362,12 +369,20 @@ main() {
   while [[ "${1:-}" == --* ]]; do
     case "$1" in
       --skip-rebase) skip_rebase=true; shift ;;
-      --squash)      shift ;;  # no-op: squash is the preferred method when allowed
-      *)             die 1 "Unknown flag: $1 — usage: merge.sh [--skip-rebase] [--squash] \"<title>\" \"<body>\"" ;;
+      --squash)      MERGE_METHOD_FLAG="squash"; shift ;;
+      --merge)       MERGE_METHOD_FLAG="merge";  shift ;;
+      --rebase)      MERGE_METHOD_FLAG="rebase"; shift ;;
+      --method)      MERGE_METHOD_FLAG="${2:?--method requires squash|merge|rebase}"; shift 2 ;;
+      *)             die 1 "Unknown flag: $1 — usage: merge.sh [--skip-rebase] [--method <squash|merge|rebase>] [--squash|--merge|--rebase] \"<title>\" \"<body>\"" ;;
     esac
   done
 
-  local title="${1:?Usage: merge.sh [--skip-rebase] \"<title>\" \"<body>\"}"
+  case "$MERGE_METHOD_FLAG" in
+    ""|squash|merge|rebase) ;;
+    *) die 1 "Invalid --method '${MERGE_METHOD_FLAG}' — must be squash, merge, or rebase" ;;
+  esac
+
+  local title="${1:?Usage: merge.sh [--skip-rebase] [--method <squash|merge|rebase>] \"<title>\" \"<body>\"}"
   local body="${2:-}"
 
   # Append co-author line
@@ -394,6 +409,14 @@ ${COAUTHOR}"
   ensure_pr "$title" "$body"
   check_pr_state
   detect_allowed_methods
+  if [[ -n "$MERGE_METHOD_FLAG" ]]; then
+    # User-forced method: narrow the strategy list to just this one. We
+    # intentionally do NOT cross-check against the probe — if the user asked
+    # for `--method rebase` on a squash-only repo, let gh produce the actual
+    # error rather than guessing from a possibly stale probe.
+    info "Method override: using only ${MERGE_METHOD_FLAG} (skipping probe-based fallback)"
+    ALLOWED_METHODS=("$MERGE_METHOD_FLAG")
+  fi
   do_merge "$title" "$body"
   fetch_merge_commit       # must precede update_local_master (uses GitHub API, not local state)
   update_local_master

--- a/agents/skills/pr/SKILL.md
+++ b/agents/skills/pr/SKILL.md
@@ -38,6 +38,26 @@ If there are uncommitted changes (check git status), stage and commit them with 
 
 ### Step 2: Push the branch
 
+#### 2a: Pre-push markdown formatting check
+
+If the pending push touches any `.md` files, run `prettier --check` against them first. Markdown table edits (e.g., adding a row to one table) often force prettier to realign column widths in *other* tables in the same file, which trips `qlty fmt` in CI. Catching it before push avoids burning a CI cycle.
+
+```bash
+md_files=$(git diff --name-only "$base_branch"...HEAD | grep -E '\.md$' || true)
+if [ -n "$md_files" ]; then
+  if ! npx --yes prettier@3.3.3 --check $md_files; then
+    echo ":: prettier reformatted markdown — running --write and re-staging"
+    npx --yes prettier@3.3.3 --write $md_files
+    git add $md_files
+    git commit -m "Format markdown via prettier"
+  fi
+fi
+```
+
+The check is cheap (~2s for a typical PR) and catches the most common qlty fmt failure mode. Skip if no `.md` files are in the diff.
+
+#### 2b: Push
+
 Push the current branch to origin. Use `git push -u origin HEAD` if no upstream is set. If there is nothing new to push, that is fine — continue to Step 3.
 
 ### Step 3: Open a PR (or use existing one)

--- a/agents/skills/pr/SKILL.md
+++ b/agents/skills/pr/SKILL.md
@@ -42,19 +42,21 @@ If there are uncommitted changes (check git status), stage and commit them with 
 
 If the pending push touches any `.md` files, run `prettier --check` against them first. Markdown table edits (e.g., adding a row to one table) often force prettier to realign column widths in *other* tables in the same file, which trips `qlty fmt` in CI. Catching it before push avoids burning a CI cycle.
 
+First determine the base ref (use `git branch -r | grep -oE 'origin/(main|master)' | head -1`), then load the changed `.md` files into a bash array so paths with spaces survive correctly:
+
 ```bash
-md_files=$(git diff --name-only "$base_branch"...HEAD | grep -E '\.md$' || true)
-if [ -n "$md_files" ]; then
-  if ! npx --yes prettier@3.3.3 --check $md_files; then
+mapfile -t md_files < <(git diff --name-only "$base_branch"...HEAD | grep -E '\.md$')
+if [ ${#md_files[@]} -gt 0 ]; then
+  if ! npx --yes prettier@3.3.3 --check "${md_files[@]}"; then
     echo ":: prettier reformatted markdown — running --write and re-staging"
-    npx --yes prettier@3.3.3 --write $md_files
-    git add $md_files
+    npx --yes prettier@3.3.3 --write "${md_files[@]}"
+    git add "${md_files[@]}"
     git commit -m "Format markdown via prettier"
   fi
 fi
 ```
 
-The check is cheap (~2s for a typical PR) and catches the most common qlty fmt failure mode. Skip if no `.md` files are in the diff.
+The check is cheap (~2s for a typical PR) and catches the most common qlty fmt failure mode. Skip if no `.md` files are in the diff. If `npx`/`prettier` is not available, skip this step entirely rather than failing the push.
 
 #### 2b: Push
 


### PR DESCRIPTION
Three skill improvements from session feedback, plus review fixes,
regression tests, and a --method override layered on top of master's
detect_allowed_methods.

- **/cross-agent**: detect subtree CLAUDE.md/AGENTS.md proactively;
  surface a per-subtree action table so monorepos migrate in one pass
  instead of leaving subtrees as an "out of scope" observation; document
  divergent-content merge validation via grep -F snippet check.
- **/merge**: add `--method <squash|merge|rebase>` (with `--squash` /
  `--merge` / `--rebase` aliases) so deliberate commit splits survive
  the merge. Layered on top of master's auto-probe — when --method is
  set, narrows ALLOWED_METHODS to that one method after the probe runs.
  Also documents the "distinct types" rebase recovery pattern when a
  branch converts files to symlinks while master independently edits
  them.
- **/pr**: add a pre-push prettier check on changed `.md` files to
  catch the qlty-fmt-fails-on-table-realignment trap before burning a
  CI cycle.

Review fixes from /ship: declared MERGE_METHOD_FLAG in globals; mapfile
for the markdown file list so paths with spaces survive; Step 4.5
cross-ref correction; swapped a Thanx-internal subtree example name
(nucleus/ → engine/) per public-repo policy. Added regression tests
covering all three new method flags that assert "unbound variable" is
absent — defends against the bash 3.2 empty-array crash class even
though the current implementation no longer has bare empty-array
expansions.

Co-Authored-By: Claude <noreply@anthropic.com>