### PR TITLE
update: run claude update and devbox version update in dots up

### DIFF
--- a/cli/commands/update/root.go
+++ b/cli/commands/update/root.go
@@ -22,6 +22,8 @@ func Run() {
 	updateZsh()
 	updateTmux()
 	updateBrew()
+	updateClaude()
+	updateDevbox()
 	updateSolargraph()
 	reshimAsdf()
 	install.Call("vim")
@@ -70,6 +72,24 @@ func updateBrew() {
 	log.Info("Updating Homebrew and outdated packages")
 	run.Verbose("brew update")
 	run.Verbose("brew upgrade")
+}
+
+func updateClaude() {
+	if err := run.Silent("which claude"); err != nil {
+		log.Info("Claude Code not installed, skipping")
+		return
+	}
+	log.Info("Updating Claude Code")
+	run.Verbose("claude update")
+}
+
+func updateDevbox() {
+	if err := run.Silent("which devbox"); err != nil {
+		log.Info("Devbox not installed, skipping")
+		return
+	}
+	log.Info("Updating Devbox")
+	run.Verbose("devbox version update")
 }
 
 func updateSolargraph() {


### PR DESCRIPTION
Adds updateClaude and updateDevbox steps to dots update (alias dots up).
Each guards on `which` and logs a skip message when the binary isn't
installed, mirroring the install-side pattern in cli/commands/install/tools.go.

Co-Authored-By: Claude <noreply@anthropic.com>