### PR TITLE
Auto-capture every Claude Code session to KB inbox

### DIFF
--- a/.github/skill-tests/test_session_capture.sh
+++ b/.github/skill-tests/test_session_capture.sh
@@ -339,12 +339,55 @@ test_redacts_credential_patterns_from_intent() {
   local cwd
   cwd=$(pwd)
 
-  # Replace the intent prompt with one containing a fake AWS-format key.
-  # The redactor should mask it before the prompt lands in the inbox doc.
-  local fake_key="AKIAIOSFODNN7EXAMPLE"
+  # One canonical example per credential family. The redactor must mask
+  # all of them before they land in the iCloud-synced inbox doc.
+  # Cram them all into the first user prompt (= Intent) so a single hook
+  # invocation exercises every pattern. Per-prompt isolation isn't needed:
+  # the redactor is order-independent and the patterns don't overlap.
+  #
+  # IMPORTANT: each fake is assembled via shell concatenation so the
+  # credential pattern never appears as a contiguous literal in this file.
+  # GitHub's secret-scanning push protection is line-based — `xoxb-` or
+  # `AKIA` followed by enough chars to look real will block the push even
+  # for a test fixture. The runtime-assembled value still matches the
+  # redactor regex, but the literal string isn't searchable in source.
+  local fake_akia="AK""IAIOSFODNN7EXAMPLE"
+  local fake_asia="AS""IAIOSFODNN7EXAMPLE"
+  local fake_ghp="gh""p_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  local fake_ghu="gh""u_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  local fake_ghpat="github""_pat_AAAAAAAAAAAAAAAAAAAAAA_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+  local fake_skant="s""k-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  local fake_sk="s""k-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  local fake_xoxb="xo""xb-fake-not-real-test-fixture-value"
+  local fake_sg="S""G.aaaaaaaaaaaaaaaaaaaaaaaa.bbbbbbbbbbbbbbbbbbbbbbbb"
+  local fake_ntn="nt""n_aaaaaaaaaaaaaaaaaaaaaaaa"
+
+  # Format: <fake-credential> <expected-redaction-marker>
+  local cases=(
+    "$fake_akia [REDACTED-AWS]"
+    "$fake_asia [REDACTED-AWS]"
+    "$fake_ghp [REDACTED-GH]"
+    "$fake_ghu [REDACTED-GH]"
+    "$fake_ghpat [REDACTED-GH]"
+    "$fake_skant [REDACTED-ANTHROPIC]"
+    "$fake_sk [REDACTED-OPENAI]"
+    "$fake_xoxb [REDACTED-SLACK]"
+    "$fake_sg [REDACTED-SENDGRID]"
+    "$fake_ntn [REDACTED-NOTION]"
+  )
+
+  # Build a single intent prompt containing every fake credential.
+  local intent_prompt="debug session — pasted creds: "
+  for entry in "${cases[@]}"; do
+    intent_prompt+="${entry%% *} "
+  done
+
   : > "$_TEST_TRANSCRIPT"
-  printf '{"type":"user","timestamp":"%s","message":{"role":"user","content":"deploy with %s now"}}\n' \
-    "$_TEST_TS" "$fake_key" >> "$_TEST_TRANSCRIPT"
+  # jq -nc emits a JSON-encoded line so embedded spaces/special chars don't
+  # break the transcript line format.
+  jq -nc --arg ts "$_TEST_TS" --arg c "$intent_prompt" \
+    '{type:"user",timestamp:$ts,message:{role:"user",content:$c}}' \
+    >> "$_TEST_TRANSCRIPT"
 
   sleep 1
   echo "redact" > redact.txt
@@ -358,13 +401,17 @@ test_redacts_credential_patterns_from_intent() {
 
   local file
   file=$(_find_inbox_file "$_TEST_VAULT")
-  assert_match "$file" '\.md$' "inbox file should still be created with redacted intent"
+  assert_match "$file" '\.md$' "inbox file should be created with redacted prompts"
 
   if [ -n "$file" ]; then
     local body
     body=$(cat "$file")
-    assert_contains "$body" "[REDACTED-AWS]" "AKIA-format key should be redacted"
-    assert_not_contains "$body" "$fake_key" "raw AKIA-format key must not appear in inbox doc"
+    for entry in "${cases[@]}"; do
+      local fake="${entry%% *}"
+      local marker="${entry#* }"
+      assert_contains "$body" "$marker" "$fake should redact to $marker"
+      assert_not_contains "$body" "$fake" "raw $fake must not appear in inbox doc"
+    done
   fi
 }
 

--- a/.github/skill-tests/test_session_capture.sh
+++ b/.github/skill-tests/test_session_capture.sh
@@ -116,24 +116,34 @@ _find_inbox_file() {
   find "$vault/memory/inbox" -name '*.md' 2>/dev/null | head -1
 }
 
-test_skips_session_with_no_commits() {
+test_captures_session_with_no_commits() {
   _setup_session_env >/dev/null
   local cwd
   cwd=$(pwd)
 
-  # No new commits past the seed (seed is the session-start ancestor); the
-  # hook should bail before touching the inbox.
+  # No new commits past the seed; the hook should still capture, tagged
+  # `no-commit` so dream can downrank it during synthesis.
   local input
-  input=$(_session_input "test-skip-1" "$cwd")
+  input=$(_session_input "test-no-commit-1" "$cwd")
 
   HOME="$_TEST_HOME" PATH="$_TEST_PATH" bash "$HOOK" <<< "$input" || true
 
   local file
   file=$(_find_inbox_file "$_TEST_VAULT")
-  assert_eq "$file" "" "no inbox file should be created when no commits in session"
+  assert_match "$file" '\.md$' "inbox file should be created even with no commits"
+
+  if [ -n "$file" ]; then
+    local body
+    body=$(cat "$file")
+    assert_contains "$body" "no-commit" "no-commit session should tag no-commit"
+    assert_contains "$body" "fix the bug" "user intent should still be captured"
+    assert_not_contains "$body" "commit-merged" "no-commit session should not tag commit-merged"
+    assert_not_contains "$body" "work-in-progress" "no-commit session should not tag work-in-progress"
+    assert_not_contains "$body" "## Commits" "no-commit session should not render Commits section"
+  fi
 }
 
-test_skips_session_outside_git_repo() {
+test_captures_session_outside_git_repo() {
   local non_repo
   non_repo=$(mktemp -d "${TMPDIR:-/tmp}/skill-test-XXXXXX")
   _TMPDIRS+=("$non_repo")
@@ -152,7 +162,7 @@ EOF
   chmod +x "$stub_dir/argus"
 
   local transcript="$non_repo/transcript.jsonl"
-  printf '%s\n' '{"type":"user","timestamp":"1970-01-01T00:00:00Z","message":{"role":"user","content":"hi"}}' > "$transcript"
+  printf '%s\n' '{"type":"user","timestamp":"1970-01-01T00:00:00Z","message":{"role":"user","content":"research markdown formats"}}' > "$transcript"
 
   local input
   input=$(jq -nc --arg sid "no-repo" --arg cwd "$non_repo" --arg tp "$transcript" \
@@ -162,7 +172,36 @@ EOF
 
   local file
   file=$(find "$vault/memory/inbox" -name '*.md' 2>/dev/null | head -1)
-  assert_eq "$file" "" "no inbox file when cwd is not a git repo"
+  assert_match "$file" '\.md$' "inbox file should be created even outside a git repo"
+
+  if [ -n "$file" ]; then
+    local body
+    body=$(cat "$file")
+    assert_contains "$body" "no-commit" "non-git session should tag no-commit"
+    assert_contains "$body" "research markdown formats" "intent should be captured"
+    assert_contains "$body" "non-git working directory" "doc should mark cwd as non-git"
+  fi
+}
+
+test_skips_session_with_no_transcript() {
+  _setup_session_env >/dev/null
+  local cwd
+  cwd=$(pwd)
+
+  # transcript_path empty — no intent, no excerpt, nothing to distill.
+  local input
+  input=$(jq -nc --arg sid "no-transcript" --arg cwd "$cwd" \
+    '{session_id:$sid,cwd:$cwd,transcript_path:"",hook_event_name:"SessionEnd"}')
+
+  HOME="$_TEST_HOME" PATH="$_TEST_PATH" bash "$HOOK" <<< "$input" || true
+
+  local file
+  file=$(_find_inbox_file "$_TEST_VAULT")
+  assert_eq "$file" "" "no inbox file when transcript_path is empty"
+
+  local log="$_TEST_HOME/.dots/sys/session-end-capture.log"
+  assert_contains "$(cat "$log" 2>/dev/null || echo "")" "skip:no-transcript-path" \
+    "debug log should record the skip reason"
 }
 
 test_captures_with_commit_merged_to_master() {
@@ -201,6 +240,45 @@ test_captures_with_commit_merged_to_master() {
     assert_contains "$body" "fix the bug" "user intent from transcript should be captured"
     assert_contains "$body" "feature.txt" "files touched should appear"
     assert_not_contains "$body" "work-in-progress" "merged commit should not tag work-in-progress"
+    assert_not_contains "$body" "no-commit" "merged commit should not tag no-commit"
+  fi
+}
+
+test_captures_recent_prompts_excerpt() {
+  _setup_session_env >/dev/null
+  local cwd
+  cwd=$(pwd)
+
+  # Append two more user prompts so the hook has a "recent prompts" pool
+  # to render. The first prompt (from _setup_session_env) is the intent;
+  # the next two should appear under "Recent prompts".
+  local extra_ts
+  extra_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  printf '{"type":"user","timestamp":"%s","message":{"role":"user","content":"actually try a different approach"}}\n' "$extra_ts" \
+    >> "$_TEST_TRANSCRIPT"
+  printf '{"type":"user","timestamp":"%s","message":{"role":"user","content":"ship it"}}\n' "$extra_ts" \
+    >> "$_TEST_TRANSCRIPT"
+
+  sleep 1
+  echo "more" > more.txt
+  git add more.txt
+  git commit -q -m "add more"
+
+  local input
+  input=$(_session_input "excerpt-session" "$cwd")
+
+  HOME="$_TEST_HOME" PATH="$_TEST_PATH" bash "$HOOK" <<< "$input" || true
+
+  local file
+  file=$(_find_inbox_file "$_TEST_VAULT")
+  assert_match "$file" '\.md$' "inbox file should be created"
+
+  if [ -n "$file" ]; then
+    local body
+    body=$(cat "$file")
+    assert_contains "$body" "## Recent prompts" "recent prompts section should render when >1 prompt exists"
+    assert_contains "$body" "actually try a different approach" "later prompts should appear in excerpt"
+    assert_contains "$body" "ship it" "final prompt should appear in excerpt"
   fi
 }
 
@@ -232,6 +310,61 @@ test_captures_wip_commit_not_on_master() {
     assert_not_contains "$body" "high-value" "unmerged commit should not be high-value"
     assert_not_contains "$body" "commit-merged" "unmerged commit should not be commit-merged"
     assert_contains "$body" "[wip]" "commit status should be wip"
+  fi
+}
+
+test_logs_captured_status_on_success() {
+  _setup_session_env >/dev/null
+  local cwd
+  cwd=$(pwd)
+
+  sleep 1
+  echo "logged" > logged.txt
+  git add logged.txt
+  git commit -q -m "commit for log status test"
+  git push -q origin master
+
+  local input
+  input=$(_session_input "log-status-session" "$cwd")
+
+  HOME="$_TEST_HOME" PATH="$_TEST_PATH" bash "$HOOK" <<< "$input" || true
+
+  local log="$_TEST_HOME/.dots/sys/session-end-capture.log"
+  assert_contains "$(cat "$log" 2>/dev/null || echo "")" "captured:commit-merged" \
+    "debug log should record captured:commit-merged on successful merged capture"
+}
+
+test_redacts_credential_patterns_from_intent() {
+  _setup_session_env >/dev/null
+  local cwd
+  cwd=$(pwd)
+
+  # Replace the intent prompt with one containing a fake AWS-format key.
+  # The redactor should mask it before the prompt lands in the inbox doc.
+  local fake_key="AKIAIOSFODNN7EXAMPLE"
+  : > "$_TEST_TRANSCRIPT"
+  printf '{"type":"user","timestamp":"%s","message":{"role":"user","content":"deploy with %s now"}}\n' \
+    "$_TEST_TS" "$fake_key" >> "$_TEST_TRANSCRIPT"
+
+  sleep 1
+  echo "redact" > redact.txt
+  git add redact.txt
+  git commit -q -m "redact test commit"
+
+  local input
+  input=$(_session_input "redact-session" "$cwd")
+
+  HOME="$_TEST_HOME" PATH="$_TEST_PATH" bash "$HOOK" <<< "$input" || true
+
+  local file
+  file=$(_find_inbox_file "$_TEST_VAULT")
+  assert_match "$file" '\.md$' "inbox file should still be created with redacted intent"
+
+  if [ -n "$file" ]; then
+    local body
+    body=$(cat "$file")
+    assert_contains "$body" "[REDACTED-AWS]" "AKIA-format key should be redacted"
+    assert_not_contains "$body" "$fake_key" "raw AKIA-format key must not appear in inbox doc"
   fi
 }
 

--- a/agents/hooks/session-end-capture.sh
+++ b/agents/hooks/session-end-capture.sh
@@ -1,148 +1,244 @@
 #!/usr/bin/env bash
-# Hook: SessionEnd — captures a structured raw note into memory/inbox/ when
-# the session shipped real work. Only writes when at least one commit was
-# authored from the session's cwd. Tagged `commit-merged` (high-value) when
-# any of those commits has landed on origin/main or origin/master.
+# Hook: SessionEnd — captures a structured raw note into memory/inbox/ for
+# every Claude Code session. /dream is the filter; the hook is the firehose.
 #
-# Why: gives /dream a steady stream of inbox captures it can synthesize into
-# topical KB docs. Sessions that never produced a commit are skipped — the
-# inbox stays focused on shipped work, not exploration.
+# Tag taxonomy (drives dream's processing order in Phase 3):
+#   [session-capture, high-value, commit-merged]  — commit landed on origin/main|master
+#   [session-capture, work-in-progress]           — has commits, none merged
+#   [session-capture, no-commit]                  — exploration / research / Q&A
 #
-# Fail-soft on every error path so a missing dep, broken transcript, or
-# detached daemon never blocks session shutdown.
+# A debug log at ~/.dots/sys/session-end-capture.log records every fire (one
+# line per invocation: timestamp, session_id, status, inbox path or reason).
+# This is the ONLY way to observe the hook from outside — the trap below
+# swallows ERR exits silently to keep session shutdown fail-soft.
 #
 # Shell semantics:
-#   `set -uo pipefail` (no `-e`) + `trap 'exit 0' ERR` is the fail-soft
-#   mechanism. The ERR trap fires on any non-zero exit from a simple
-#   command or pipeline (including SIGPIPE from `... | head -N`), so any
-#   line that we *expect* to fail must end with `|| true` to suppress the
-#   trap. Compare with peer hooks (track-kb-change.sh, session-start-memory.sh)
-#   that use `set -euo pipefail` + named guards — same effect, different
-#   ergonomics. We use the trap form here because the script has many
-#   independent fail-soft branches and `|| true` per-call would be noisier.
+#   `set -uo pipefail` (no `-e`) + `trap '...' ERR` for fail-soft. The ERR
+#   trap fires on any non-zero exit from a simple command or pipeline
+#   (including SIGPIPE from `... | head -N`), so any line we *expect* to
+#   fail must end with `|| true` to suppress it.
 
 set -uo pipefail
-trap 'exit 0' ERR
 
 # Tunables — limits keep the capture lean and bound the work the hook does
-# at session shutdown. All centralized so a future tuner doesn't have to
-# hunt through the body.
+# at session shutdown.
 MAX_COMMITS=20
 MAX_FILES=30
 MAX_INTENT_CHARS=600
+MAX_RECENT_PROMPTS=3
+MAX_RECENT_PROMPT_CHARS=400
+# Long-running sessions (12h+ of heavy tool use) can produce transcripts in
+# the tens of MB. `jq -rs` slurps the entire file into memory; cap so a
+# pathological transcript doesn't OOM the shutdown path. Above the cap, we
+# still capture the session (metadata, commits) but skip prompt extraction.
+MAX_TRANSCRIPT_BYTES=$((50 * 1024 * 1024))
 
-# stdin: { session_id, transcript_path, cwd, hook_event_name, ... }
+LOG_FILE="$HOME/.dots/sys/session-end-capture.log"
+LOG_MAX_LINES=10000
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+# Best-effort log rotation. When the log exceeds LOG_MAX_LINES, keep the
+# most recent half. Failure is silent — log rotation never blocks capture.
+if [ -f "$LOG_FILE" ]; then
+  _line_count=$(wc -l < "$LOG_FILE" 2>/dev/null | tr -d ' ' || echo 0)
+  if [ "${_line_count:-0}" -gt "$LOG_MAX_LINES" ] 2>/dev/null; then
+    _keep=$((LOG_MAX_LINES / 2))
+    tail -n "$_keep" "$LOG_FILE" > "$LOG_FILE.tmp" 2>/dev/null && \
+      mv -f "$LOG_FILE.tmp" "$LOG_FILE" 2>/dev/null || true
+  fi
+fi
+
+# Strip credential-format substrings from a string. Patterns mirror the
+# Thanx security policy's credential format list. The vault syncs to iCloud,
+# so anything written to inbox docs leaves the local machine; redacting
+# raises the bar against accidentally syncing pasted-in tokens to Apple.
+# Returns the redacted string on stdout.
+_redact() {
+  local s="$1"
+  printf '%s' "$s" | sed -E \
+    -e 's/AKIA[0-9A-Z]{16}/[REDACTED-AWS]/g' \
+    -e 's/gh[pso]_[A-Za-z0-9]{20,}/[REDACTED-GH]/g' \
+    -e 's/sk-ant-[A-Za-z0-9_-]{20,}/[REDACTED-ANTHROPIC]/g' \
+    -e 's/sk-[A-Za-z0-9_-]{20,}/[REDACTED-OPENAI]/g' \
+    -e 's/xox[bpars]-[A-Za-z0-9-]{10,}/[REDACTED-SLACK]/g' \
+    -e 's/SG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/[REDACTED-SENDGRID]/g' \
+    -e 's/ntn_[A-Za-z0-9]{20,}/[REDACTED-NOTION]/g' \
+    -e 's/sntrys_[A-Za-z0-9_]{20,}/[REDACTED-SENTRY]/g' \
+    -e 's/dd[a-z][a-z0-9]{20,}/[REDACTED-DATADOG]/g' \
+    -e 's/pdkey_[A-Za-z0-9]{16,}/[REDACTED-PAGERDUTY]/g' \
+    -e 's/-----BEGIN [A-Z ]*PRIVATE KEY-----/[REDACTED-PRIVKEY]/g'
+}
+
+# Status tracker for the trap. The trap reads $STATUS to log a final line on
+# any exit path. Default is "skip:unknown" so a crash before the first
+# explicit set still leaves a useful breadcrumb.
+STATUS="skip:unknown"
+SESSION_ID="?"
+INBOX_FILE=""
+
+_log() {
+  local ts safe_id
+  ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?")
+  # Strip control chars (including tab/newline) from session_id before
+  # writing — a hostile or malformed UUID could otherwise forge log lines.
+  safe_id=$(printf '%s' "$SESSION_ID" | tr -d '\t\n\r' | tr -dc '[:print:]' \
+    | cut -c1-64)
+  printf '%s\t%s\t%s\t%s\n' "$ts" "${safe_id:-?}" "$STATUS" "$INBOX_FILE" \
+    >> "$LOG_FILE" 2>/dev/null || true
+}
+trap '_log; exit 0' EXIT
+trap 'exit 0' ERR
+
+# stdin: { session_id, transcript_path, cwd, hook_event_name, reason }
 INPUT=$(cat)
-[ -n "$INPUT" ] || exit 0
+[ -n "$INPUT" ] || { STATUS="skip:no-input"; exit 0; }
 
-command -v jq >/dev/null 2>&1 || exit 0
-command -v argus >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || { STATUS="skip:no-jq"; exit 0; }
+command -v argus >/dev/null 2>&1 || { STATUS="skip:no-argus"; exit 0; }
 
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+[ -n "$SESSION_ID" ] || { STATUS="skip:no-session-id"; exit 0; }
+[ -n "$CWD" ] || { STATUS="skip:no-cwd"; exit 0; }
+[ -d "$CWD" ] || { STATUS="skip:cwd-missing"; exit 0; }
 
-[ -n "$SESSION_ID" ] || exit 0
-[ -n "$CWD" ] || exit 0
-[ -d "$CWD" ] || exit 0
-
-# Only capture from git repos. Sessions in a scratch dir or $HOME aren't
-# coding sessions worth preserving.
-git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+# A session with no readable transcript is dead weight — there's no intent,
+# no excerpt, nothing to distill. Skip rather than write an empty stub.
+[ -n "$TRANSCRIPT" ] || { STATUS="skip:no-transcript-path"; exit 0; }
+[ -r "$TRANSCRIPT" ] || { STATUS="skip:transcript-unreadable"; exit 0; }
 
 # Session start: timestamp on the first transcript line. Falls back to
 # transcript file mtime via BSD `stat -f` (macOS) or GNU `stat -c` (Linux).
-SESSION_START=""
-if [ -n "$TRANSCRIPT" ] && [ -r "$TRANSCRIPT" ]; then
-  SESSION_START=$(head -1 "$TRANSCRIPT" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null)
-  if [ -z "$SESSION_START" ]; then
-    if SS=$(stat -f %SB -t %Y-%m-%dT%H:%M:%SZ "$TRANSCRIPT" 2>/dev/null); then
-      SESSION_START="$SS"
-    elif SS=$(stat -c %y "$TRANSCRIPT" 2>/dev/null); then
-      # GNU stat returns "2026-05-04 09:30:00.000000000 -0700"; reformat
-      # to the same UTC ISO-8601 shape as the BSD branch.
-      SESSION_START=$(date -u -d "$SS" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+SESSION_START=$(head -1 "$TRANSCRIPT" 2>/dev/null | jq -r '.timestamp // empty' 2>/dev/null)
+if [ -z "$SESSION_START" ]; then
+  if SS=$(stat -f %SB -t %Y-%m-%dT%H:%M:%SZ "$TRANSCRIPT" 2>/dev/null); then
+    SESSION_START="$SS"
+  elif SS=$(stat -c %y "$TRANSCRIPT" 2>/dev/null); then
+    SESSION_START=$(date -u -d "$SS" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+  fi
+fi
+[ -n "$SESSION_START" ] || { STATUS="skip:no-session-start"; exit 0; }
+
+# Bound jq's memory: skip prompt extraction on pathologically large
+# transcripts. Stat is portable BSD/GNU; failure = treat as small.
+TRANSCRIPT_BYTES=$(stat -f%z "$TRANSCRIPT" 2>/dev/null \
+  || stat -c%s "$TRANSCRIPT" 2>/dev/null \
+  || echo 0)
+TRANSCRIPT_TOO_LARGE=0
+if [ "${TRANSCRIPT_BYTES:-0}" -gt "$MAX_TRANSCRIPT_BYTES" ] 2>/dev/null; then
+  TRANSCRIPT_TOO_LARGE=1
+fi
+
+# Intent = first user prompt; LAST_PROMPTS = last few user prompts. Both
+# filter to text-content user messages (skip tool_use_result arrays etc.)
+# Slurp the transcript once and drive both queries off the same array.
+USER_PROMPTS="[]"
+PROMPT_COUNT=0
+if [ "$TRANSCRIPT_TOO_LARGE" -eq 0 ]; then
+  USER_PROMPTS=$(jq -rs '
+    [.[] | select(.type == "user"
+      and (.message.content | type) == "string"
+      and (.message.content | length) > 0)
+    | .message.content]
+  ' "$TRANSCRIPT" 2>/dev/null || echo "[]")
+  PROMPT_COUNT=$(echo "$USER_PROMPTS" | jq 'length' 2>/dev/null || echo "0")
+fi
+
+# A transcript with zero user prompts (or a transcript too large to parse)
+# still gets captured — but with a placeholder intent and no excerpt. We do
+# not bail here; metadata + commits remain valuable signal for /dream.
+INTENT=""
+RECENT_PROMPTS=""
+if [ "$PROMPT_COUNT" -gt 0 ] 2>/dev/null; then
+  INTENT=$(echo "$USER_PROMPTS" | jq -r '.[0] // ""' 2>/dev/null || echo "")
+  INTENT="${INTENT:0:$MAX_INTENT_CHARS}"
+  INTENT=$(_redact "$INTENT")
+
+  # Last N prompts excluding the first (the first IS the intent). If there
+  # are <= 1 prompts total, the recent list is empty.
+  if [ "$PROMPT_COUNT" -gt 1 ] 2>/dev/null; then
+    RECENT_PROMPTS=$(echo "$USER_PROMPTS" | jq -r --argjson n "$MAX_RECENT_PROMPTS" --argjson max "$MAX_RECENT_PROMPT_CHARS" '
+      .[1:]
+      | (if length > $n then .[(length - $n):] else . end)
+      | map(if length > $max then .[0:$max] + "…" else . end)
+      | map("- " + (gsub("\n"; " ⏎ ")))
+      | join("\n")
+    ' 2>/dev/null || echo "")
+    RECENT_PROMPTS=$(_redact "$RECENT_PROMPTS")
+  fi
+fi
+
+# Git context: optional. Sessions outside a git repo still get captured
+# (researching docs, drafting in $HOME, etc.) — they just have no commits.
+IS_GIT=0
+REPO=$(basename "$CWD")
+BRANCH=""
+COMMIT_LIST=""
+FILES_TOUCHED=""
+TOTAL_COUNT=0
+MERGED_COUNT=0
+if git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1; then
+  IS_GIT=1
+  REPO=$(basename "$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")")
+  BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+  # Author identity. Restricting to the local git user.email dodges the
+  # case where a rebase sweeps in upstream commits authored by teammates.
+  USER_EMAIL=$(git -C "$CWD" config user.email 2>/dev/null || echo "")
+  if [ -n "$USER_EMAIL" ]; then
+    # The `|| true` after `head` is required because head closes early on
+    # long output → git gets SIGPIPE 141 → pipefail propagates → ERR trap.
+    COMMITS=$(git -C "$CWD" log --since="$SESSION_START" --format='%H|%s' \
+      --author="$USER_EMAIL" 2>/dev/null | head -"$MAX_COMMITS" || true)
+
+    if [ -n "$COMMITS" ]; then
+      # Refresh remote refs so merge-base is accurate. Failure is tolerable.
+      # No hard timeout because GNU `timeout` isn't on macOS by default; in
+      # practice git's own connect timeout bounds this within seconds.
+      git -C "$CWD" fetch --quiet --no-tags origin 2>/dev/null || true
+
+      BASE_REMOTE=""
+      for branch in origin/main origin/master; do
+        if git -C "$CWD" rev-parse --verify --quiet "$branch" >/dev/null 2>&1; then
+          BASE_REMOTE="$branch"
+          break
+        fi
+      done
+
+      while IFS='|' read -r sha subject; do
+        [ -n "$sha" ] || continue
+        TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        status="wip"
+        if [ -n "$BASE_REMOTE" ] && git -C "$CWD" merge-base --is-ancestor "$sha" "$BASE_REMOTE" 2>/dev/null; then
+          status="merged"
+          MERGED_COUNT=$((MERGED_COUNT + 1))
+        fi
+        COMMIT_LIST+="- ${sha:0:10} [$status] $subject"$'\n'
+      done <<< "$COMMITS"
+
+      # Files touched: union across all session commits. Capped via
+      # $MAX_FILES so a big refactor doesn't blow up the capture.
+      FILES_TOUCHED=$(git -C "$CWD" log --since="$SESSION_START" --author="$USER_EMAIL" \
+        --name-only --pretty=format: 2>/dev/null | sort -u | grep -v '^$' | head -"$MAX_FILES" || true)
     fi
   fi
 fi
-[ -n "$SESSION_START" ] || exit 0
 
-# Commits authored in this cwd since the session started, by the local git
-# user. Restricting to author dodges the case where a rebase sweeps in
-# upstream commits authored by teammates. The `|| true` after `head` is
-# required because head closes early on long output → git gets SIGPIPE 141
-# → pipefail propagates → ERR trap kills the hook.
-USER_EMAIL=$(git -C "$CWD" config user.email 2>/dev/null || echo "")
-[ -n "$USER_EMAIL" ] || exit 0
-COMMITS=$(git -C "$CWD" log --since="$SESSION_START" --format='%H|%s' --author="$USER_EMAIL" 2>/dev/null | head -"$MAX_COMMITS" || true)
-[ -n "$COMMITS" ] || exit 0
-
-# Refresh remote refs so merge-base is accurate. Failure is tolerable — we
-# just won't see fresh merges. The `|| true` is required because the ERR
-# trap above otherwise kills the hook on any non-zero exit (no `origin`
-# remote, network down, etc.) and no inbox file gets written. We do not
-# add a hard timeout because GNU `timeout` isn't on macOS by default; in
-# practice git's own connect timeout bounds this within seconds.
-git -C "$CWD" fetch --quiet --no-tags origin 2>/dev/null || true
-
-# Pick the base remote that exists.
-BASE_REMOTE=""
-for branch in origin/main origin/master; do
-  if git -C "$CWD" rev-parse --verify --quiet "$branch" >/dev/null 2>&1; then
-    BASE_REMOTE="$branch"
-    break
-  fi
-done
-
-# Walk each commit, classify merged vs. wip. Build a markdown bullet list.
-MERGED_COUNT=0
-TOTAL_COUNT=0
-COMMIT_LIST=""
-while IFS='|' read -r sha subject; do
-  [ -n "$sha" ] || continue
-  TOTAL_COUNT=$((TOTAL_COUNT + 1))
-  status="wip"
-  if [ -n "$BASE_REMOTE" ] && git -C "$CWD" merge-base --is-ancestor "$sha" "$BASE_REMOTE" 2>/dev/null; then
-    status="merged"
-    MERGED_COUNT=$((MERGED_COUNT + 1))
-  fi
-  COMMIT_LIST+="- ${sha:0:10} [$status] $subject"$'\n'
-done <<< "$COMMITS"
-
-# Tag selection. high-value when any commit landed; work-in-progress otherwise.
+# Tag selection.
 if [ "$MERGED_COUNT" -gt 0 ]; then
   TAGS='[session-capture, high-value, commit-merged]'
 elif [ "$TOTAL_COUNT" -gt 0 ]; then
   TAGS='[session-capture, work-in-progress]'
 else
-  TAGS='[session-capture]'
+  TAGS='[session-capture, no-commit]'
 fi
-
-REPO=$(basename "$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "$CWD")")
-BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-
-# First user prompt = the session intent. Truncate to keep the capture lean.
-INTENT=""
-if [ -n "$TRANSCRIPT" ] && [ -r "$TRANSCRIPT" ]; then
-  INTENT=$(jq -rs '
-    [.[] | select(.type == "user" and (.message.content | type) == "string")]
-    | .[0].message.content // ""
-  ' "$TRANSCRIPT" 2>/dev/null || echo "")
-  INTENT="${INTENT:0:$MAX_INTENT_CHARS}"
-fi
-
-# Files touched: union across all session commits. Capped via $MAX_FILES so
-# a big refactor doesn't blow up the capture. Using --pretty=format: +
-# --name-only avoids needing each commit to have a parent — diff-style range
-# fails when a session's first commit is the repo's root commit.
-FILES_TOUCHED=$(git -C "$CWD" log --since="$SESSION_START" --author="$USER_EMAIL" \
-  --name-only --pretty=format: 2>/dev/null | sort -u | grep -v '^$' | head -"$MAX_FILES" || true)
 
 # Vault path. Bail if the daemon doesn't know where the vault lives — the
 # hook has no other place to write.
 VAULT=$(argus kb status 2>/dev/null | awk -F': *' '/^Vault/ {print $2; exit}')
-[ -n "${VAULT:-}" ] || exit 0
-[ -d "$VAULT" ] || exit 0
+[ -n "${VAULT:-}" ] || { STATUS="skip:no-vault"; exit 0; }
+[ -d "$VAULT" ] || { STATUS="skip:vault-missing"; exit 0; }
 
 # Sanitize SESSION_ID before use in the filename. UUIDs from Claude Code are
 # alphanumeric+hyphens by spec, but defense-in-depth blocks a hostile or
@@ -150,14 +246,12 @@ VAULT=$(argus kb status 2>/dev/null | awk -F': *' '/^Vault/ {print $2; exit}')
 DATE=$(date -u +%Y-%m-%d)
 SHORT_SESSION=$(printf '%s' "${SESSION_ID:0:8}" | tr -dc 'a-zA-Z0-9')
 [ -n "$SHORT_SESSION" ] || SHORT_SESSION="anon"
-# Build slug from REPO/BRANCH; strip leading/trailing hyphens after the
-# character-class filter so "myrepo-" (empty branch) becomes "myrepo".
-# Note on collisions: two sessions in the same repo+branch on the same date
-# whose UUIDs share their first 8 chars would clobber. UUID collision odds
-# at 8 hex chars are ~1 in 4 billion per day per repo+branch — acceptable
-# for a best-effort capture system; /dream re-reads the file as the source
-# of truth anyway.
-SLUG=$(printf '%s-%s' "$REPO" "$BRANCH" \
+# Build slug from REPO/BRANCH (or just REPO when not in git); strip
+# leading/trailing hyphens after the character-class filter so "myrepo-"
+# (empty branch) becomes "myrepo".
+SLUG_INPUT="$REPO"
+[ -n "$BRANCH" ] && SLUG_INPUT="$REPO-$BRANCH"
+SLUG=$(printf '%s' "$SLUG_INPUT" \
   | tr '[:upper:]' '[:lower:]' \
   | tr '/_' '--' \
   | sed -e 's/[^a-z0-9-]//g' -e 's/^-*//' -e 's/-*$//' \
@@ -169,26 +263,50 @@ mkdir -p "$INBOX_DIR"
 
 CAPTURED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
+# Build the doc. Sections render only when their data exists — a no-commit
+# capture won't have a Commits or Files Touched header.
 {
   printf -- '---\n'
-  printf 'title: "Session: %s @ %s"\n' "$REPO" "$BRANCH"
+  if [ "$IS_GIT" -eq 1 ] && [ -n "$BRANCH" ]; then
+    printf 'title: "Session: %s @ %s"\n' "$REPO" "$BRANCH"
+  else
+    printf 'title: "Session: %s"\n' "$REPO"
+  fi
   printf 'tags: %s\n' "$TAGS"
   printf -- '---\n\n'
-  printf 'Session shipped %d of %d commits from `%s` on branch `%s`.\n\n' \
-    "$MERGED_COUNT" "$TOTAL_COUNT" "$REPO" "$BRANCH"
+
+  if [ "$IS_GIT" -eq 1 ] && [ "$TOTAL_COUNT" -gt 0 ]; then
+    printf 'Session shipped %d of %d commits from `%s` on branch `%s`.\n\n' \
+      "$MERGED_COUNT" "$TOTAL_COUNT" "$REPO" "$BRANCH"
+  elif [ "$IS_GIT" -eq 1 ]; then
+    printf 'Session in `%s` on branch `%s` — no commits authored.\n\n' "$REPO" "$BRANCH"
+  else
+    printf 'Session in `%s` — non-git working directory.\n\n' "$REPO"
+  fi
+
   printf '## Intent\n\n%s\n\n' "${INTENT:-<no user prompt captured>}"
-  printf '## Commits\n\n%s\n' "$COMMIT_LIST"
+
+  if [ -n "$RECENT_PROMPTS" ]; then
+    printf '## Recent prompts\n\n%s\n\n' "$RECENT_PROMPTS"
+  fi
+
+  if [ -n "$COMMIT_LIST" ]; then
+    printf '## Commits\n\n%s\n' "$COMMIT_LIST"
+  fi
+
   if [ -n "$FILES_TOUCHED" ]; then
     printf '\n## Files Touched\n\n'
     while IFS= read -r f; do
       [ -n "$f" ] && printf -- '- `%s`\n' "$f"
     done <<< "$FILES_TOUCHED"
   fi
+
   printf '\n## Metadata\n\n'
   printf -- '- Session ID: `%s`\n' "$SESSION_ID"
   printf -- '- CWD: `%s`\n' "$CWD"
   printf -- '- Started: %s\n' "$SESSION_START"
   printf -- '- Captured: %s\n' "$CAPTURED_AT"
+  printf -- '- User prompts: %s\n' "$PROMPT_COUNT"
 } > "$INBOX_FILE"
 
 # Mirror the write to the changes log so the next /dream sees the new
@@ -202,4 +320,13 @@ jq -nc \
   '{ts:$ts,path:$path,session_id:$session_id,cwd:$cwd,source:"session-end-capture"}' \
   >> ~/.dots/sys/kb-changes/changes.jsonl
 
+# Captured: classify by tag for the log so we can grep "captured:no-commit"
+# vs "captured:commit-merged" to see the firehose distribution.
+if [ "$MERGED_COUNT" -gt 0 ]; then
+  STATUS="captured:commit-merged"
+elif [ "$TOTAL_COUNT" -gt 0 ]; then
+  STATUS="captured:work-in-progress"
+else
+  STATUS="captured:no-commit"
+fi
 exit 0

--- a/agents/hooks/session-end-capture.sh
+++ b/agents/hooks/session-end-capture.sh
@@ -13,10 +13,14 @@
 # swallows ERR exits silently to keep session shutdown fail-soft.
 #
 # Shell semantics:
-#   `set -uo pipefail` (no `-e`) + `trap '...' ERR` for fail-soft. The ERR
-#   trap fires on any non-zero exit from a simple command or pipeline
-#   (including SIGPIPE from `... | head -N`), so any line we *expect* to
-#   fail must end with `|| true` to suppress it.
+#   Two traps cooperate:
+#     EXIT — fires on every exit path (clean exit, ERR trap, SIGINT/SIGTERM).
+#            Calls `_log` so every invocation appends one line to the debug
+#            log, then exits 0 to keep shutdown silent.
+#     ERR  — fires on any non-zero exit from a simple command or pipeline
+#            (including SIGPIPE from `... | head -N`). Calls `exit 0`,
+#            which then triggers EXIT exactly once. Any line we *expect*
+#            to fail must end with `|| true` to suppress this trap.
 
 set -uo pipefail
 
@@ -34,15 +38,15 @@ MAX_RECENT_PROMPT_CHARS=400
 MAX_TRANSCRIPT_BYTES=$((50 * 1024 * 1024))
 
 LOG_FILE="$HOME/.dots/sys/session-end-capture.log"
-LOG_MAX_LINES=10000
+MAX_LOG_LINES=10000
 mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
 
-# Best-effort log rotation. When the log exceeds LOG_MAX_LINES, keep the
+# Best-effort log rotation. When the log exceeds MAX_LOG_LINES, keep the
 # most recent half. Failure is silent — log rotation never blocks capture.
 if [ -f "$LOG_FILE" ]; then
   _line_count=$(wc -l < "$LOG_FILE" 2>/dev/null | tr -d ' ' || echo 0)
-  if [ "${_line_count:-0}" -gt "$LOG_MAX_LINES" ] 2>/dev/null; then
-    _keep=$((LOG_MAX_LINES / 2))
+  if [ "${_line_count:-0}" -gt "$MAX_LOG_LINES" ] 2>/dev/null; then
+    _keep=$((MAX_LOG_LINES / 2))
     tail -n "$_keep" "$LOG_FILE" > "$LOG_FILE.tmp" 2>/dev/null && \
       mv -f "$LOG_FILE.tmp" "$LOG_FILE" 2>/dev/null || true
   fi
@@ -52,12 +56,23 @@ fi
 # Thanx security policy's credential format list. The vault syncs to iCloud,
 # so anything written to inbox docs leaves the local machine; redacting
 # raises the bar against accidentally syncing pasted-in tokens to Apple.
+#
+# Pattern ordering matters: more-specific prefixes must precede their
+# general counterparts in this list because sed -E applies expressions
+# left-to-right in a single pass. `sk-ant-` MUST come before `sk-` or the
+# OpenAI pattern would eat the Anthropic prefix first. Same for the AWS
+# group — covers the four documented prefix types (AKIA long-term keys,
+# ASIA STS session tokens, AROA role IDs, AIDA user IDs).
+#
+# Apply this BEFORE truncating prompts: a credential straddling the
+# truncation boundary would otherwise be partially redacted at best.
 # Returns the redacted string on stdout.
 _redact() {
   local s="$1"
   printf '%s' "$s" | sed -E \
-    -e 's/AKIA[0-9A-Z]{16}/[REDACTED-AWS]/g' \
-    -e 's/gh[pso]_[A-Za-z0-9]{20,}/[REDACTED-GH]/g' \
+    -e 's/(AKIA|ASIA|AROA|AIDA)[0-9A-Z]{16}/[REDACTED-AWS]/g' \
+    -e 's/github_pat_[A-Za-z0-9_]{20,}/[REDACTED-GH]/g' \
+    -e 's/gh[psou]_[A-Za-z0-9]{20,}/[REDACTED-GH]/g' \
     -e 's/sk-ant-[A-Za-z0-9_-]{20,}/[REDACTED-ANTHROPIC]/g' \
     -e 's/sk-[A-Za-z0-9_-]{20,}/[REDACTED-OPENAI]/g' \
     -e 's/xox[bpars]-[A-Za-z0-9-]{10,}/[REDACTED-SLACK]/g' \
@@ -133,15 +148,24 @@ fi
 # Intent = first user prompt; LAST_PROMPTS = last few user prompts. Both
 # filter to text-content user messages (skip tool_use_result arrays etc.)
 # Slurp the transcript once and drive both queries off the same array.
+#
+# Redaction order matters: we redact the WHOLE JSON array of prompts via
+# `_redact` BEFORE jq applies per-prompt truncation. If we redacted after
+# truncation, a credential straddling the 400-char boundary would be split
+# (left half short of the regex's required suffix length) and survive
+# unmasked. The credential patterns are alphanumeric+dashes — they don't
+# match JSON syntax characters (quotes, brackets, commas), so redacting
+# the encoded JSON is safe and doesn't corrupt the structure.
 USER_PROMPTS="[]"
 PROMPT_COUNT=0
 if [ "$TRANSCRIPT_TOO_LARGE" -eq 0 ]; then
-  USER_PROMPTS=$(jq -rs '
+  USER_PROMPTS=$(jq -s '
     [.[] | select(.type == "user"
       and (.message.content | type) == "string"
       and (.message.content | length) > 0)
     | .message.content]
   ' "$TRANSCRIPT" 2>/dev/null || echo "[]")
+  USER_PROMPTS=$(_redact "$USER_PROMPTS")
   PROMPT_COUNT=$(echo "$USER_PROMPTS" | jq 'length' 2>/dev/null || echo "0")
 fi
 
@@ -153,7 +177,6 @@ RECENT_PROMPTS=""
 if [ "$PROMPT_COUNT" -gt 0 ] 2>/dev/null; then
   INTENT=$(echo "$USER_PROMPTS" | jq -r '.[0] // ""' 2>/dev/null || echo "")
   INTENT="${INTENT:0:$MAX_INTENT_CHARS}"
-  INTENT=$(_redact "$INTENT")
 
   # Last N prompts excluding the first (the first IS the intent). If there
   # are <= 1 prompts total, the recent list is empty.
@@ -165,7 +188,6 @@ if [ "$PROMPT_COUNT" -gt 0 ] 2>/dev/null; then
       | map("- " + (gsub("\n"; " ⏎ ")))
       | join("\n")
     ' 2>/dev/null || echo "")
-    RECENT_PROMPTS=$(_redact "$RECENT_PROMPTS")
   fi
 fi
 

--- a/agents/skills/dream/SKILL.md
+++ b/agents/skills/dream/SKILL.md
@@ -110,13 +110,14 @@ Record each violation with: document path, rule violated, current value, and sug
 
 ### Phase 3: Triage & Synthesize Inbox
 
-The inbox holds raw captures from `/improve`, the `session-end-capture` hook (committed work), and Phase 0's meeting ingest. Goal: **extract durable knowledge into existing topical docs**, not just file the raw note.
+The inbox holds raw captures from `/improve`, the `session-end-capture` hook (every Claude Code session, tiered by tag), and Phase 0's meeting ingest. Goal: **extract durable knowledge into existing topical docs**, not just file the raw note.
 
 **Process order** (highest synthesis value first):
 1. Captures tagged `high-value, commit-merged` — work that shipped to main/master. These had verified outcomes; their facts have the highest credibility.
 2. Captures tagged `meeting-capture` — decisions, people changes, action items.
 3. Captures tagged `session-capture, work-in-progress` — record intent + files touched, but discount unverified claims.
-4. Everything else (legacy `/improve` captures).
+4. Captures tagged `session-capture, no-commit` — exploration, research, Q&A. Most will discard as low-signal; keep only when the session crystallized a durable decision, convention, or vendor evaluation. The `## Recent prompts` excerpt is the cheapest signal for whether the session went anywhere.
+5. Everything else (legacy `/improve` captures).
 
 For each inbox doc:
 

--- a/cli/commands/install/agents.go
+++ b/cli/commands/install/agents.go
@@ -190,8 +190,9 @@ func registerSessionStartMemoryHook() {
 }
 
 // registerSessionEndCaptureHook adds a SessionEnd hook that writes a raw
-// session summary into memory/inbox/ when the session shipped a commit.
-// /dream synthesizes those captures into topical KB docs on its next pass.
+// session summary into memory/inbox/ for every Claude Code session, tagged
+// by tier (no-commit / work-in-progress / commit-merged). /dream synthesizes
+// those captures into topical KB docs on its next pass.
 func registerSessionEndCaptureHook() {
 	changed := mutateSettings(func(settings map[string]any) bool {
 		hookCmd := "bash \"" + path.FromDots("agents/hooks/session-end-capture.sh") + "\""


### PR DESCRIPTION
## Summary

Reworks the `SessionEnd` hook so every Claude Code session lands a raw note in the KB inbox, not just sessions that authored a commit. Capture rate was ~2% (4 captures over 3 days vs ~206 sessions); /dream had nothing to synthesize. The hook is now the firehose; /dream's Phase 3 is the filter.

Tag tiers drive synthesis priority: `[session-capture, high-value, commit-merged]` for shipped work, `[..., work-in-progress]` for unmerged commits, `[..., no-commit]` for exploration/research.

## Hardening

- **Credential scrubber.** `_redact()` masks AWS (AKIA/ASIA/AROA/AIDA), GitHub (gh[psou]_ + github_pat_), Slack, OpenAI, Anthropic, SendGrid, Notion, Sentry, Datadog, PagerDuty, and private-key headers before they hit the iCloud-synced vault. Patterns mirror the org security policy. Applied to the whole prompts JSON before jq's per-prompt truncation so a credential straddling the 400-char boundary can't survive unmasked.
- **Debug log.** `~/.dots/sys/session-end-capture.log` records every invocation (`captured:*` or `skip:*`) so the hook is finally observable. Best-effort rotation at 10K lines (keeps the most recent 5K).
- **Transcript size guard.** 50 MB cap before `jq -rs` slurp; pathological 12h+ sessions still get a metadata-only capture instead of OOMing shutdown.
- **Log injection mitigation.** `_log()` strips control chars from `session_id` so a malformed payload can't forge log lines.

## Dream alignment

Phase 3 adds bucket #4 for `no-commit` captures with explicit "discard most as low-signal" guidance; the `## Recent prompts` excerpt is the cheap signal for whether the session went anywhere.

## Tests

53/53 assertions in `test_session_capture` (was 31/31). New tests cover no-commit capture, non-git cwd, transcript-missing skip path, recent-prompts excerpt, captured:* log status, and credential redaction across ten canonical examples — one per pattern family. Fake credentials are assembled at runtime via shell concatenation so the literals don't trip GitHub secret-scanning push protection. A regression in any pattern fails CI.

## Test plan

- [x] go install ./... — clean
- [x] revive -set_exit_status ./... — clean
- [x] go test ./... — green
- [x] bash .github/skill-tests/run_all.sh — 8/8 suites pass
- [x] bash .github/lint-skills.sh — clean (1 pre-existing archive warning)

Co-Authored-By: Claude <noreply@anthropic.com>