### PR TITLE
Fix CI: disable agnix CC-SK-008 for unknown Claude Code tools

### DIFF
--- a/.agnix.toml
+++ b/.agnix.toml
@@ -22,7 +22,11 @@ cross_platform = false
 xml_balance = false
 
 # Suppress known false positives
-disabled_rules = ["AGM-006"]  # Multiple/nested AGENTS.md — intentional with openspec
+disabled_rules = [
+  "AGM-006",   # Multiple/nested AGENTS.md — intentional with openspec
+  "CC-SK-008", # Unknown tool — agnix 0.13.0 doesn't recognize newer Claude Code tools
+               # (Monitor, ScheduleWakeup, PushNotification, etc.) that real skills depend on
+]
 
 # Exclude openspec-managed files from prompt engineering rules
 [files]


### PR DESCRIPTION
## Summary
- CI on `master` has been failing the `Agent Config Lint (agnix)` step since the `/orchestrate-stack` skill was added.
- agnix 0.13.0 emits `CC-SK-008` errors for `Monitor`, `ScheduleWakeup`, and `PushNotification` — all valid Claude Code tools agnix simply doesn't know yet.
- Suppress `CC-SK-008` in `.agnix.toml` rather than stripping real tool entries from the skill frontmatter.

## Test plan
- [x] `npx agnix@0.13.0 .` exits 0 locally (was exit 1, 3 errors)
- [x] `bash .github/lint-skills.sh` still passes
- [ ] CI green on PR