### PR TITLE
Auto-switch worktree to master after squash merge

### DIFF
--- a/agents/skills/merge/SKILL.md
+++ b/agents/skills/merge/SKILL.md
@@ -73,7 +73,7 @@ Resolve the script path — use the first that exists:
 2. `agents/skills/merge/scripts/merge.sh` (repo-relative, for development/workspaces)
 
 ```
-bash <script-path> [--method <squash|merge|rebase>] "<title>" "<body>"
+bash <script-path> [--method <squash|merge|rebase>] [--keep-branch] "<title>" "<body>"
 ```
 
 #### Choosing a merge method
@@ -85,6 +85,15 @@ The script defaults to **squash** (collapses all commits into one). Pick a diffe
 - `--method rebase` (alias `--rebase`) — preserves all commits linearly via fast-forward / rebase. **Use this when the user has deliberately split work into multiple commits** (e.g., the user ran `/squash` to condense 7 commits into 2 separate logical commits, and wants both on master). A naive squash merge here would silently undo that intent.
 
 Heuristic: if the branch has more than one commit AND the commit messages look distinct rather than incremental ("WIP", "fix typo"), confirm with the user before using the default squash. The deliberate-split case is common after `/squash`.
+
+#### Post-merge worktree state
+
+After a successful **squash** merge, the script auto-switches the current worktree to the default branch (`master`/`main`). This prevents the next agent or follow-up task in this worktree from committing against the now-divergent feature branch — squash collapses all commits into one new commit on master, so the old feature branch HEAD no longer shares history with the merged result.
+
+- `--method merge` / `--method rebase` — auto-switch is **off** by default. Both methods preserve the original commits, so the feature branch may still be useful for stacked PRs or chained follow-on work.
+- `--keep-branch` — opt out of auto-switch on squash. The worktree stays on the feature branch and the script prints a divergence warning instead. Use this for stacked-PR workflows that squash but still need to keep the branch checked out (rare).
+
+If auto-switch fails (e.g., uncommitted changes in the worktree, or `master` is checked out in another worktree), the script falls back to a loud warning rather than aborting — the merge itself already succeeded.
 
 #### Handle the exit code
 

--- a/agents/skills/merge/scripts/merge.sh
+++ b/agents/skills/merge/scripts/merge.sh
@@ -3,13 +3,18 @@ set -euo pipefail
 
 # merge.sh — Merge current branch to the default branch via GitHub PR
 #
-# Usage: merge.sh [--skip-rebase] [--method <squash|merge|rebase>] [--squash|--merge|--rebase] "<title>" "<body>"
+# Usage: merge.sh [--skip-rebase] [--method <squash|merge|rebase>] [--squash|--merge|--rebase] [--keep-branch] "<title>" "<body>"
 #
 # Without an explicit method, merge.sh probes the repo's allowed methods and
 # tries them in preference order (squash → rebase → merge). Pass --method (or
 # the matching shorthand) to force a single method — useful when the user
 # deliberately split a branch into multiple commits and wants `gh pr merge
 # --rebase` to preserve them on master, even on a repo that allows squash.
+#
+# After a successful squash merge, the worktree is auto-switched to the
+# default branch so follow-up work doesn't commit against the now-divergent
+# feature branch. Pass --keep-branch to suppress that (or use --method
+# rebase/merge, which preserve commits and skip the auto-switch).
 #
 # Exit codes:
 #   0 — success (merge completed or auto-merge enabled)
@@ -37,6 +42,7 @@ PR_MERGE_STATE=""
 PR_REVIEW_DECISION=""
 LAST_GH_ERR=""
 MERGE_METHOD_FLAG=""  # input flag (squash|merge|rebase|""); narrows ALLOWED_METHODS when set
+KEEP_BRANCH=false     # when true, restore checkout to feature branch after squash merge
 
 # --- Helpers ---
 
@@ -321,15 +327,37 @@ update_local_master() {
 
   info "Updating local ${DEFAULT_BRANCH}..."
 
+  # Squash collapses the feature branch's commits into one new commit on the
+  # default branch, leaving the feature branch divergent. Any follow-up work in
+  # this worktree would commit against a stale base. Auto-switch to the default
+  # branch unless the user explicitly opted out with --keep-branch, or used a
+  # non-squash method (rebase/merge preserve commits, so the branch may still
+  # be useful for stacked-PR or chained-work flows).
+  local auto_switch=false
+  if [[ "$KEEP_BRANCH" == false && "$MERGE_METHOD" == squash* ]]; then
+    auto_switch=true
+  fi
+
   if git checkout "$DEFAULT_BRANCH" 2>/dev/null; then
     git pull "$TARGET" "$DEFAULT_BRANCH"
-    git checkout "$BRANCH" 2>/dev/null || true
+    if [[ "$auto_switch" == true ]]; then
+      info "Worktree now on ${DEFAULT_BRANCH} ('${BRANCH}' was squashed and is now divergent)."
+    else
+      git checkout "$BRANCH" 2>/dev/null || true
+      info "NOTE: worktree is still on '${BRANCH}' (now divergent from ${DEFAULT_BRANCH})."
+      info "      Run 'git checkout ${DEFAULT_BRANCH}' before continuing work in this worktree,"
+      info "      or 'git reset --hard ${TARGET}/${DEFAULT_BRANCH}' to reuse this branch name."
+    fi
   else
     local worktree_path
     worktree_path=$(git worktree list | grep "\[${DEFAULT_BRANCH}\]" | awk '{print $1}' || echo "")
     if [[ -n "$worktree_path" ]]; then
       info "Pulling ${DEFAULT_BRANCH} in worktree: ${worktree_path}"
       git -C "$worktree_path" pull "$TARGET" "$DEFAULT_BRANCH" 2>/dev/null || true
+    fi
+    if [[ "$auto_switch" == true ]]; then
+      info "NOTE: could not auto-switch this worktree to ${DEFAULT_BRANCH} — still on '${BRANCH}' (now divergent)."
+      info "      Run 'git checkout ${DEFAULT_BRANCH}' or 'git reset --hard ${TARGET}/${DEFAULT_BRANCH}' before continuing."
     fi
   fi
 }
@@ -373,7 +401,8 @@ main() {
       --merge)       MERGE_METHOD_FLAG="merge";  shift ;;
       --rebase)      MERGE_METHOD_FLAG="rebase"; shift ;;
       --method)      MERGE_METHOD_FLAG="${2:?--method requires squash|merge|rebase}"; shift 2 ;;
-      *)             die 1 "Unknown flag: $1 — usage: merge.sh [--skip-rebase] [--method <squash|merge|rebase>] [--squash|--merge|--rebase] \"<title>\" \"<body>\"" ;;
+      --keep-branch) KEEP_BRANCH=true; shift ;;
+      *)             die 1 "Unknown flag: $1 — usage: merge.sh [--skip-rebase] [--method <squash|merge|rebase>] [--squash|--merge|--rebase] [--keep-branch] \"<title>\" \"<body>\"" ;;
     esac
   done
 

--- a/agents/skills/merge/scripts/merge.sh
+++ b/agents/skills/merge/scripts/merge.sh
@@ -34,7 +34,8 @@ PR_NUMBER=""
 PR_URL=""
 REPO_SLUG=""
 ALLOWED_METHODS=()
-MERGE_METHOD=""
+MERGE_METHOD=""       # full method label including tier suffix, e.g. "squash" or "squash (admin)"
+MERGE_METHOD_BASE=""  # bare method name (squash|rebase|merge), without tier suffix
 MERGE_STATUS="merged"
 MERGE_COMMIT=""
 DOTS_SYNCED=""
@@ -255,6 +256,7 @@ do_merge() {
     for method in "${ALLOWED_METHODS[@]}"; do
       if _gh_merge "$method" "--admin" "$title" "$body"; then
         MERGE_METHOD="${method} (admin)"
+        MERGE_METHOD_BASE="$method"
         return 0
       fi
     done
@@ -264,6 +266,7 @@ do_merge() {
     for method in "${ALLOWED_METHODS[@]}"; do
       if _gh_merge "$method" "--auto" "$title" "$body"; then
         MERGE_METHOD="${method} (auto-merge)"
+        MERGE_METHOD_BASE="$method"
         MERGE_STATUS="auto-merge enabled (${reason})"
         return 0
       fi
@@ -277,6 +280,7 @@ do_merge() {
   for method in "${ALLOWED_METHODS[@]}"; do
     if _gh_merge "$method" "" "$title" "$body"; then
       MERGE_METHOD="$method"
+      MERGE_METHOD_BASE="$method"
       return 0
     fi
   done
@@ -287,6 +291,7 @@ do_merge() {
   for method in "${ALLOWED_METHODS[@]}"; do
     if _gh_merge "$method" "--admin" "$title" "$body"; then
       MERGE_METHOD="${method} (admin)"
+      MERGE_METHOD_BASE="$method"
       return 0
     fi
   done
@@ -297,6 +302,7 @@ do_merge() {
   for method in "${ALLOWED_METHODS[@]}"; do
     if _gh_merge "$method" "--auto" "$title" "$body"; then
       MERGE_METHOD="${method} (auto-merge)"
+      MERGE_METHOD_BASE="$method"
       MERGE_STATUS="auto-merge enabled"
       return 0
     fi
@@ -332,9 +338,11 @@ update_local_master() {
   # this worktree would commit against a stale base. Auto-switch to the default
   # branch unless the user explicitly opted out with --keep-branch, or used a
   # non-squash method (rebase/merge preserve commits, so the branch may still
-  # be useful for stacked-PR or chained-work flows).
+  # be useful for stacked-PR or chained-work flows). MERGE_METHOD_BASE is set
+  # by do_merge() to the bare method name (squash|rebase|merge), independent
+  # of the tier suffix used in MERGE_METHOD.
   local auto_switch=false
-  if [[ "$KEEP_BRANCH" == false && "$MERGE_METHOD" == squash* ]]; then
+  if [[ "$KEEP_BRANCH" == false && "$MERGE_METHOD_BASE" == "squash" ]]; then
     auto_switch=true
   fi
 
@@ -349,6 +357,8 @@ update_local_master() {
       info "      or 'git reset --hard ${TARGET}/${DEFAULT_BRANCH}' to reuse this branch name."
     fi
   else
+    # Checkout failed: typically because no local ref for $DEFAULT_BRANCH exists
+    # yet, or master is checked out in another worktree. Both share this branch.
     local worktree_path
     worktree_path=$(git worktree list | grep "\[${DEFAULT_BRANCH}\]" | awk '{print $1}' || echo "")
     if [[ -n "$worktree_path" ]]; then
@@ -357,7 +367,12 @@ update_local_master() {
     fi
     if [[ "$auto_switch" == true ]]; then
       info "NOTE: could not auto-switch this worktree to ${DEFAULT_BRANCH} — still on '${BRANCH}' (now divergent)."
-      info "      Run 'git checkout ${DEFAULT_BRANCH}' or 'git reset --hard ${TARGET}/${DEFAULT_BRANCH}' before continuing."
+      if [[ -n "$worktree_path" ]]; then
+        info "      ${DEFAULT_BRANCH} is checked out in worktree '${worktree_path}'."
+      else
+        info "      Run 'git fetch ${TARGET} ${DEFAULT_BRANCH}' to create a local ref, then"
+      fi
+      info "      'git checkout ${DEFAULT_BRANCH}' or 'git reset --hard ${TARGET}/${DEFAULT_BRANCH}' before continuing."
     fi
   fi
 }

--- a/agents/skills/pr/SKILL.md
+++ b/agents/skills/pr/SKILL.md
@@ -40,23 +40,34 @@ If there are uncommitted changes (check git status), stage and commit them with 
 
 #### 2a: Pre-push markdown formatting check
 
-If the pending push touches any `.md` files, run `prettier --check` against them first. Markdown table edits (e.g., adding a row to one table) often force prettier to realign column widths in *other* tables in the same file, which trips `qlty fmt` in CI. Catching it before push avoids burning a CI cycle.
+If the pending push touches any `.md` files, run `prettier --check` against them first **only when the repo actually enforces prettier**. Markdown table edits often force prettier to realign column widths in *other* tables in the same file, which trips `qlty fmt` in CI. Catching it before push avoids burning a CI cycle — but reformatting against a repo that doesn't enforce prettier can introduce regressions on files whose existing style differs from prettier's preferred output (e.g., joining `0.`-prefixed list items, swapping italics `*` ↔ `_`, adding blank lines after list intros).
 
-First determine the base ref (use `git branch -r | grep -oE 'origin/(main|master)' | head -1`), then load the changed `.md` files into a bash array so paths with spaces survive correctly:
+Gate on the presence of a prettier or qlty config in the repo. If none is found, skip this step.
 
 ```bash
-mapfile -t md_files < <(git diff --name-only "$base_branch"...HEAD | grep -E '\.md$')
-if [ ${#md_files[@]} -gt 0 ]; then
-  if ! npx --yes prettier@3.3.3 --check "${md_files[@]}"; then
-    echo ":: prettier reformatted markdown — running --write and re-staging"
-    npx --yes prettier@3.3.3 --write "${md_files[@]}"
-    git add "${md_files[@]}"
-    git commit -m "Format markdown via prettier"
+prettier_enforced=false
+for cfg in .prettierrc .prettierrc.json .prettierrc.yml .prettierrc.yaml .prettierrc.js .prettierrc.cjs .prettierrc.toml prettier.config.js prettier.config.cjs .qlty/qlty.toml; do
+  [ -e "$cfg" ] && { prettier_enforced=true; break; }
+done
+# Also detect prettier/qlty referenced from CI workflows
+if [ "$prettier_enforced" = false ] && grep -rlE 'prettier|qlty' .github/workflows 2>/dev/null | grep -q .; then
+  prettier_enforced=true
+fi
+
+if [ "$prettier_enforced" = true ]; then
+  mapfile -t md_files < <(git diff --name-only "$base_branch"...HEAD | grep -E '\.md$')
+  if [ ${#md_files[@]} -gt 0 ]; then
+    if ! npx --yes prettier@3.3.3 --check "${md_files[@]}"; then
+      echo ":: prettier reformatted markdown — running --write and re-staging"
+      npx --yes prettier@3.3.3 --write "${md_files[@]}"
+      git add "${md_files[@]}"
+      git commit -m "Format markdown via prettier"
+    fi
   fi
 fi
 ```
 
-The check is cheap (~2s for a typical PR) and catches the most common qlty fmt failure mode. Skip if no `.md` files are in the diff. If `npx`/`prettier` is not available, skip this step entirely rather than failing the push.
+The check is cheap (~2s for a typical PR) and catches the most common qlty fmt failure mode. Skip if no `.md` files are in the diff, if no prettier/qlty config is present, or if `npx`/`prettier` is not available — rather than failing the push or risking unrelated reformatting.
 
 #### 2b: Push
 

--- a/agents/skills/ship/SKILL.md
+++ b/agents/skills/ship/SKILL.md
@@ -31,12 +31,13 @@ You orchestrate a 6-phase pipeline to take the current branch from "done coding"
 3. **Improve** — analyze session for learnings and fix gaps (inline, not via `/improve`)
 4. **Address improvements** — apply approved improvements
 5. **Merge** — run `/merge` to land the branch
+5b. **Switch worktree to default branch** — hygiene step so follow-up work starts from the new tip
 
 If any phase has nothing to do (no findings, no improvements), skip it and move on.
 
 ## Continue Protocol
 
-**All 6 phases must execute in a single unbroken sequence.** After any sub-skill returns (`/review`, `/merge`) or any inline analysis completes, immediately proceed to the next phase. Never treat a sub-skill return or analysis report as the end of your task. The pipeline is only complete after Phase 5 finishes or an abort condition is hit.
+**All phases must execute in a single unbroken sequence.** After any sub-skill returns (`/review`, `/merge`) or any inline analysis completes, immediately proceed to the next phase. Never treat a sub-skill return or analysis report as the end of your task. The pipeline is only complete after Phase 5b finishes or an abort condition is hit.
 
 ---
 
@@ -158,6 +159,20 @@ Invoke the `/merge` skill to land the branch into master.
 Handle merge script exit codes as documented in the `/merge` skill (conflicts, nothing to merge, review blocked, errors).
 
 **If CI fails on tests unrelated to your PR**, fix them inline as part of `/ship` rather than rebasing or treating the merge as blocked. Pre-existing flakes (timing-sensitive tests, data races on shared mutable state, environment-dependent assertions) are normal during a `/ship` cycle on a project with sparse CI history. Capture each fix as its own commit with a message that names the flake and the cause (e.g., "fix flaky-test sleep timing on slower CI" or "fix data race on shared buffer under -race") so the rationale stays clear in history. Then re-run `/merge`.
+
+## Phase 5b: Switch worktree to default branch
+
+After `/merge` returns success, ensure the worktree is on the default branch so any follow-up work (or any other agent invoked next in this worktree) starts from the new tip rather than the squashed-out feature branch. This is belt-and-suspenders alongside `/merge`'s own auto-switch — if `/merge` already switched (default for squash), this is a no-op; if the user passed `--keep-branch` or used `--method rebase`/`--method merge`, this still rescues the follow-up agent path.
+
+Detect the default branch and switch:
+
+```bash
+DEFAULT_BRANCH=$(git branch -r 2>/dev/null | grep -oE 'origin/(main|master)' | head -1 | sed 's|origin/||')
+[ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH="master"
+git checkout "$DEFAULT_BRANCH" 2>/dev/null && git pull --ff-only
+```
+
+If the checkout fails (uncommitted changes, no local default-branch ref, another worktree owns it, etc.), **warn but do not abort** — the pipeline is complete; this is hygiene. Print the current branch and a one-line note that follow-up work in this worktree should `git checkout "$DEFAULT_BRANCH"` (or `git reset --hard origin/"$DEFAULT_BRANCH"`) before committing.
 
 ---
 

--- a/agents/skills/ship/SKILL.md
+++ b/agents/skills/ship/SKILL.md
@@ -164,12 +164,12 @@ Handle merge script exit codes as documented in the `/merge` skill (conflicts, n
 
 After `/merge` returns success, ensure the worktree is on the default branch so any follow-up work (or any other agent invoked next in this worktree) starts from the new tip rather than the squashed-out feature branch. This is belt-and-suspenders alongside `/merge`'s own auto-switch — if `/merge` already switched (default for squash), this is a no-op; if the user passed `--keep-branch` or used `--method rebase`/`--method merge`, this still rescues the follow-up agent path.
 
-Detect the default branch and switch:
+Detect the default branch and switch. This is a simplified probe that only recognizes `main` / `master` — `/merge` itself uses the GitHub API (`gh api repos/<slug>`) for canonical detection and handles repos with non-standard default names. If your repo's default is something else (e.g., `trunk`), `/merge`'s own auto-switch already handled it and this phase is a no-op; skip Phase 5b for those repos rather than relying on the fallback below.
 
 ```bash
 DEFAULT_BRANCH=$(git branch -r 2>/dev/null | grep -oE 'origin/(main|master)' | head -1 | sed 's|origin/||')
 [ -z "$DEFAULT_BRANCH" ] && DEFAULT_BRANCH="master"
-git checkout "$DEFAULT_BRANCH" 2>/dev/null && git pull --ff-only
+git checkout "$DEFAULT_BRANCH" 2>/dev/null && git pull --ff-only origin "$DEFAULT_BRANCH"
 ```
 
 If the checkout fails (uncommitted changes, no local default-branch ref, another worktree owns it, etc.), **warn but do not abort** — the pipeline is complete; this is hygiene. Print the current branch and a one-line note that follow-up work in this worktree should `git checkout "$DEFAULT_BRANCH"` (or `git reset --hard origin/"$DEFAULT_BRANCH"`) before committing.
@@ -197,4 +197,5 @@ After the pipeline completes (or aborts), print:
 | Improve | {done/skipped} | {N improvements applied} |
 | Address Improvements | {done/skipped} | {N commits} |
 | Merge | {done/blocked/failed} | {PR URL or error} |
+| Switch Worktree | {done/skipped/warned} | {current branch after switch, or warning} |
 ```


### PR DESCRIPTION
## Summary

- `/merge` now auto-switches the worktree to the default branch after a successful **squash** merge so follow-up work doesn't commit against the now-divergent feature branch.
- Adds `--keep-branch` opt-out for stacked-PR / chained workflows. `--method rebase` / `--method merge` keep the original return-to-feature-branch behavior (those methods preserve commits, so the branch may still be useful).
- If auto-switch fails (uncommitted changes, master checked out in another worktree, etc.), the script falls back to a loud divergence warning rather than aborting — the merge itself already succeeded.
- `/ship` gains **Phase 5b** as a defensive hygiene step after Phase 5: belt-and-suspenders for cases where `/merge` was called with `--keep-branch` or a non-squash method.
- Also gates `/pr`'s pre-push prettier check on repo enforcement (presence of `.prettierrc` / `.qlty` config or a CI workflow referencing prettier/qlty), since running prettier unconditionally introduced regressions in repos with non-prettier-compliant existing markdown.

## Root cause

`update_local_master()` in `merge.sh` fast-forwarded the local `master` ref but then ran `git checkout "$BRANCH"` to restore the worktree to the feature branch. After a squash merge, the feature branch is divergent from `master` — its commits no longer share history with the squashed commit that landed. Any follow-up work in this worktree (e.g., a chained Argus task) committed against the stale base and tripped the post-squash-merge divergence pattern handled in `/ship` Phase 0. Last hit: a fix-ship-retry cycle producing two follow-up PRs in `drn/metis` from a single original ship.

Internally, `do_merge()` sets `MERGE_METHOD` to a tier-suffixed label (`"squash"`, `"squash (admin)"`, etc.). To decouple `update_local_master`'s auto-switch decision from that label format, this change introduces `MERGE_METHOD_BASE` (bare method name) alongside `MERGE_METHOD` and checks against the base.

## Test plan

- [x] `bash -n agents/skills/merge/scripts/merge.sh` (syntax)
- [x] `.github/skill-tests/test_merge.sh` — 39/39 assertions pass
- [x] `.github/skill-tests/run_all.sh` — 8/8 suites pass
- [x] `.github/lint-skills.sh` — passes (pre-existing warnings only, none on touched files)
- [x] `go install ./...`, `go test ./...`, `revive -set_exit_status ./...` — all clean
- [x] Self-merge: this PR's own merge will exercise the new auto-switch path. Worktree should land on `master` after `/merge` returns.

Co-Authored-By: Claude <noreply@anthropic.com>