### PR TITLE
Enable tmux extended-keys for modified Enter

### DIFF
--- a/home/tmux.conf
+++ b/home/tmux.conf
@@ -5,6 +5,10 @@ set -g default-shell $SHELL
 set -g default-command "reattach-to-user-namespace -l ${SHELL}"
 # disable Esc delay
 set -sg escape-time 0
+# enable extended keys so apps can distinguish Shift/Ctrl/Alt + Enter
+# (Claude Code uses Shift+Enter for newlines, Option+Enter for queued input)
+set -g extended-keys on
+set -as terminal-features 'xterm*:extkeys'
 # set terminal type (tmux-256color enables modern escape sequence passthrough)
 set -g default-terminal "tmux-256color"
 # enable truecolor terminal support and DECSET 2026 (Synchronized Output)

--- a/home/tmux.conf
+++ b/home/tmux.conf
@@ -5,10 +5,6 @@ set -g default-shell $SHELL
 set -g default-command "reattach-to-user-namespace -l ${SHELL}"
 # disable Esc delay
 set -sg escape-time 0
-# enable extended keys so apps can distinguish Shift/Ctrl/Alt + Enter
-# (Claude Code uses Shift+Enter for newlines, Option+Enter for queued input)
-set -g extended-keys on
-set -as terminal-features 'xterm*:extkeys'
 # set terminal type (tmux-256color enables modern escape sequence passthrough)
 set -g default-terminal "tmux-256color"
 # enable truecolor terminal support and DECSET 2026 (Synchronized Output)
@@ -16,6 +12,10 @@ set -g default-terminal "tmux-256color"
 # that tcell emits per frame, producing stacked-status-bar tearing on
 # layout shifts (resize, page swap, agent enter/exit).
 set -as terminal-features ',xterm-256color:RGB:sync'
+# enable extended keys so apps that bind modified Enter (Shift/Ctrl/Alt+Enter)
+# receive distinct sequences instead of plain Enter
+set -s extended-keys on
+set -as terminal-features ',xterm*:extkeys'
 # set history size to 10k
 set -g history-limit 100000
 # Use vim keybindings in copy mode


### PR DESCRIPTION
Without `extended-keys on`, tmux folds Shift/Ctrl/Alt+Enter onto plain
Enter, so apps that bind those keys can't distinguish them.

- Set `extended-keys on` at server scope (the option's actual scope).
- Advertise `extkeys` for `xterm*` so tmux emits CSI u sequences to the
  outer terminal when supported.
- Place the block after `default-terminal` to match the existing
  RGB:sync ordering convention.

Triggered by the tmux startup warning recommending this setting.

Co-Authored-By: Claude <noreply@anthropic.com>