### PR TITLE
Add pi.dev install component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ home/bundle/cache
 sys
 .claude/settings.local.json
 .claude/worktrees
+pi/agent/auth.json
+pi/agent/sessions/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ dots doctor                                   # Run diagnostics
 | tools | Devbox, Claude Code, Codex |
 | osx | macOS defaults |
 | agents | Agent skills, custom agents, hooks, and status line (symlinks agents/skills → ~/.claude/skills + ~/.agents/skills, agents/custom → ~/.claude/agents, registers hooks and status line in ~/.claude/settings.json) |
+| pi | pi.dev coding agent CLI + config (installs pi via curl pi.dev/install.sh, symlinks pi/agent/models.json → ~/.pi/agent/models.json; auth.json and sessions/ stay local) |
 
 ## Writing Skills / Slash Commands
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ dots docker stop-all     # Stop all Docker containers
 | `vim` | Vim/Neovim configuration with vim-plug and plugins |
 | `hammerspoon` | Lua-based window management and macOS automation |
 | `osx` | macOS system preferences and defaults |
+| `pi` | pi.dev coding agent CLI + config (installs `pi` via `curl pi.dev/install.sh`, symlinks `pi/agent/models.json` → `~/.pi/agent/models.json`; `auth.json` and `sessions/` stay local) |
 
 ## Agent Skills
 
@@ -184,6 +185,7 @@ Run `dots install agents` to symlink them to `~/.claude/agents/`.
 ├── git/                       # Git extensions and hooks
 ├── hammerspoon/               # Lua automation scripts (with tests)
 ├── fonts/                     # Developer fonts
+├── pi/                        # pi.dev coding agent config (models.json only)
 │
 ├── agents/                    # Agent configuration
 │   ├── skills/                # 58 reusable skills (SKILL.md per skill)

--- a/agents/skills/rereview/SKILL.md
+++ b/agents/skills/rereview/SKILL.md
@@ -18,8 +18,8 @@ Re-review all branch changes from scratch with independent competing reviewers. 
 - Git status: !`git status --short`
 - Project type: !`ls go.mod Gemfile package.json Cargo.toml pyproject.toml 2>/dev/null | head -5`
 - Test framework: !`git ls-files 2>/dev/null | grep -E '_test\.|\.test\.|_spec\.' | head -10`
-- Changes vs main: !`git diff --stat HEAD...origin/main 2>/dev/null | head -50`
-- Changes vs master: !`git diff --stat HEAD...origin/master 2>/dev/null | head -50`
+- Changes vs main: !`git diff --stat origin/main...HEAD 2>/dev/null | head -50`
+- Changes vs master: !`git diff --stat origin/master...HEAD 2>/dev/null | head -50`
 
 ## Overview
 

--- a/agents/skills/review/SKILL.md
+++ b/agents/skills/review/SKILL.md
@@ -15,8 +15,8 @@ Run a comprehensive code review (security, architecture, clarity) against your c
 
 - Current branch: !`git branch --show-current`
 - Base ref: !`git branch -r 2>/dev/null | grep -oE 'origin/(main|master)' | head -1`
-- Changes vs main: !`git diff --stat HEAD...origin/main 2>/dev/null | head -50`
-- Changes vs master: !`git diff --stat HEAD...origin/master 2>/dev/null | head -50`
+- Changes vs main: !`git diff --stat origin/main...HEAD 2>/dev/null | head -50`
+- Changes vs master: !`git diff --stat origin/master...HEAD 2>/dev/null | head -50`
 
 ## Phase Protocol
 

--- a/agents/skills/ship/SKILL.md
+++ b/agents/skills/ship/SKILL.md
@@ -17,8 +17,8 @@ Run the full review-fix-improve-fix-merge pipeline to ship the current branch.
 - Current branch: !`git branch --show-current`
 - Base ref: !`git branch -r 2>/dev/null | grep -oE 'origin/(main|master)' | head -1`
 - Git status: !`git status --short`
-- Changes vs main: !`git diff --stat HEAD...origin/main 2>/dev/null | head -50`
-- Changes vs master: !`git diff --stat HEAD...origin/master 2>/dev/null | head -50`
+- Changes vs main: !`git diff --stat origin/main...HEAD 2>/dev/null | head -50`
+- Changes vs master: !`git diff --stat origin/master...HEAD 2>/dev/null | head -50`
 
 ## Overview
 

--- a/agents/skills/write-skill/SKILL.md
+++ b/agents/skills/write-skill/SKILL.md
@@ -96,8 +96,10 @@ Claude Code blocks `$()` inside dynamic context expressions for security reasons
 - Base ref: !{git branch -r 2>/dev/null | grep -oE 'origin/(main|master)' | head -1}
 - Commits vs main: !{git log origin/main..HEAD --oneline 2>/dev/null | head -20}
 - Commits vs master: !{git log origin/master..HEAD --oneline 2>/dev/null | head -20}
-- Changes vs main: !{git diff --stat HEAD...origin/main 2>/dev/null | head -50}
-- Changes vs master: !{git diff --stat HEAD...origin/master 2>/dev/null | head -50}
+# Triple-dot direction matters: `base...HEAD` shows changes ON the branch.
+# `HEAD...base` shows changes ON base since branch diverged — the reverse.
+- Changes vs main: !{git diff --stat origin/main...HEAD 2>/dev/null | head -50}
+- Changes vs master: !{git diff --stat origin/master...HEAD 2>/dev/null | head -50}
 ```
 
 **Alternatives to `$()`:**

--- a/cli/commands/install/pi.go
+++ b/cli/commands/install/pi.go
@@ -1,0 +1,39 @@
+package install
+
+import (
+	"os"
+
+	"github.com/drn/dots/cli/link"
+	"github.com/drn/dots/pkg/log"
+	"github.com/drn/dots/pkg/path"
+	"github.com/drn/dots/pkg/run"
+)
+
+// Pi - Installs pi.dev coding agent and configuration
+//
+// Only models.json is tracked. auth.json (provider API keys) and sessions/
+// (per-session state) stay local and out of git.
+func Pi() {
+	log.Action("Install Pi")
+
+	installPi()
+
+	agentDir := path.FromHome(".pi/agent")
+	if err := os.MkdirAll(agentDir, 0755); err != nil {
+		log.Error("Failed to create %s: %s", agentDir, err.Error())
+		return
+	}
+
+	link.Soft(
+		path.FromDots("pi/agent/models.json"),
+		path.FromHome(".pi/agent/models.json"),
+	)
+}
+
+func installPi() {
+	if err := run.Silent("which pi"); err == nil {
+		log.Info("pi.dev already installed")
+		return
+	}
+	exec("curl -fsSL https://pi.dev/install.sh | sh")
+}

--- a/cli/commands/install/pi.go
+++ b/cli/commands/install/pi.go
@@ -14,10 +14,13 @@ import (
 // Only models.json is tracked. auth.json (provider API keys) and sessions/
 // (per-session state) stay local and out of git.
 func Pi() {
-	log.Action("Install Pi")
+	log.Action("Install pi.dev")
 
 	installPi()
 
+	// Always reconcile the config symlink, even if the binary is already
+	// installed — re-running `dots install pi` should restore the link if
+	// it was removed or replaced.
 	agentDir := path.FromHome(".pi/agent")
 	if err := os.MkdirAll(agentDir, 0755); err != nil {
 		log.Error("Failed to create %s: %s", agentDir, err.Error())

--- a/cli/commands/install/root.go
+++ b/cli/commands/install/root.go
@@ -34,6 +34,7 @@ func Components() []Component {
 		{"tools", "Installs dev tools (Devbox, Claude Code, Codex)", "", Tools},
 		{"osx", "Installs OSX configuration", "", Osx},
 		{"agents", "Installs agent skills (Claude Code + Codex)", "", Agents},
+		{"pi", "Installs pi.dev coding agent and configuration", "", Pi},
 	}
 }
 

--- a/pi/agent/models.json
+++ b/pi/agent/models.json
@@ -1,0 +1,12 @@
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "models": [
+        { "id": "qwen3:32b" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add a `pi` install component that installs the pi.dev CLI (via
`curl pi.dev/install.sh`) and symlinks `pi/agent/models.json` into
`~/.pi/agent/`. Tracks only the model config (Ollama qwen3:32b);
`auth.json` and `sessions/` stay local, with defensive `.gitignore`
patterns.

Also fixes a reversed triple-dot diff in the review/ship/rereview/
write-skill SKILL.md context blocks — `HEAD...origin/master` showed
changes ON master since branch diverged (the reverse of intent);
flipped to `origin/master...HEAD` so review skills see the actual
branch diff.

Co-Authored-By: Claude <noreply@anthropic.com>