### PR TITLE
Replace imroc/req with net/http in spotify CLI

### DIFF
--- a/cmd/spotify/auth/root.go
+++ b/cmd/spotify/auth/root.go
@@ -4,6 +4,8 @@ package auth
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -11,10 +13,11 @@ import (
 	"github.com/drn/dots/cli/config"
 	"github.com/drn/dots/pkg/log"
 	"github.com/drn/dots/pkg/run"
-	"github.com/imroc/req"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/manifoldco/promptui"
 )
+
+const spotifyTokenURL = "https://accounts.spotify.com/api/token"
 
 // FetchAccessToken - Returns a valid access token for the Spotify API.
 // * If no cached access token or refresh token
@@ -60,53 +63,77 @@ func authorize() {
 }
 
 func refreshNeeded(accessToken string) bool {
-	url := "https://api.spotify.com/v1/me"
-	response, err := req.Put(url, Headers(accessToken))
-	HandleRequestError(err)
-	return response.Response().StatusCode == 401
+	_, status := SendRequest(http.MethodPut, "https://api.spotify.com/v1/me", Headers(accessToken), nil, nil)
+	return status == http.StatusUnauthorized
 }
 
 // Headers returns the standard Spotify API request headers.
-func Headers(accessToken string) req.Header {
-	return req.Header{
-		"Accept":        "application/json",
-		"Content-Type":  "application/json",
-		"Authorization": "Bearer " + accessToken,
+func Headers(accessToken string) http.Header {
+	return http.Header{
+		"Accept":        {"application/json"},
+		"Content-Type":  {"application/json"},
+		"Authorization": {"Bearer " + accessToken},
 	}
 }
 
-const spotifyTokenURL = "https://accounts.spotify.com/api/token"
-
 func exchangeAuthorizationCode(code string) (string, string) {
-	data := exchangeToken(req.Param{
-		"code":       code,
-		"grant_type": "authorization_code",
+	data := exchangeToken(url.Values{
+		"code":       {code},
+		"grant_type": {"authorization_code"},
 	})
 	return jsoniter.Get(data, "access_token").ToString(),
 		jsoniter.Get(data, "refresh_token").ToString()
 }
 
 func exchangeRefreshToken(code string) string {
-	data := exchangeToken(req.Param{
-		"refresh_token": code,
-		"grant_type":    "refresh_token",
+	data := exchangeToken(url.Values{
+		"refresh_token": {code},
+		"grant_type":    {"refresh_token"},
 	})
 	return jsoniter.Get(data, "access_token").ToString()
 }
 
-func exchangeToken(params req.Param) []byte {
-	params["client_id"] = os.Getenv("SPOTIFY_CLIENT_ID")
-	params["client_secret"] = os.Getenv("SPOTIFY_CLIENT_SECRET")
-	params["redirect_uri"] = os.Getenv("SPOTIFY_REDIRECT_URI")
+func exchangeToken(params url.Values) []byte {
+	params.Set("client_id", os.Getenv("SPOTIFY_CLIENT_ID"))
+	params.Set("client_secret", os.Getenv("SPOTIFY_CLIENT_SECRET"))
+	params.Set("redirect_uri", os.Getenv("SPOTIFY_REDIRECT_URI"))
 
-	response, err := req.Post(spotifyTokenURL, params)
-	HandleRequestError(err)
-
-	if response.Response().StatusCode != 200 {
-		fmt.Println(string(response.Bytes()))
+	headers := http.Header{"Content-Type": {"application/x-www-form-urlencoded"}}
+	data, status := SendRequest(
+		http.MethodPost, spotifyTokenURL, headers, nil, strings.NewReader(params.Encode()),
+	)
+	if status != http.StatusOK {
+		fmt.Println(string(data))
 		os.Exit(1)
 	}
-	return response.Bytes()
+	return data
+}
+
+// SendRequest performs an HTTP request with optional query params and body,
+// returning the response body and status code. Exits on transport errors.
+func SendRequest(
+	method, baseURL string,
+	headers http.Header,
+	query url.Values,
+	body io.Reader,
+) ([]byte, int) {
+	fullURL := baseURL
+	if len(query) > 0 {
+		fullURL = baseURL + "?" + query.Encode()
+	}
+	request, err := http.NewRequest(method, fullURL, body)
+	HandleRequestError(err)
+	if headers != nil {
+		request.Header = headers
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	HandleRequestError(err)
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	HandleRequestError(err)
+	return data, response.StatusCode
 }
 
 func inputCode() string {

--- a/cmd/spotify/auth/root.go
+++ b/cmd/spotify/auth/root.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/drn/dots/cli/config"
 	"github.com/drn/dots/pkg/log"
@@ -18,6 +19,10 @@ import (
 )
 
 const spotifyTokenURL = "https://accounts.spotify.com/api/token"
+
+// httpClient bounds Spotify API calls to a reasonable interactive timeout so
+// the CLI can't hang on a stalled connection.
+var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 // FetchAccessToken - Returns a valid access token for the Spotify API.
 // * If no cached access token or refresh token
@@ -63,7 +68,7 @@ func authorize() {
 }
 
 func refreshNeeded(accessToken string) bool {
-	_, status := SendRequest(http.MethodPut, "https://api.spotify.com/v1/me", Headers(accessToken), nil, nil)
+	_, status := SendRequest(http.MethodGet, "https://api.spotify.com/v1/me", Headers(accessToken), nil, nil)
 	return status == http.StatusUnauthorized
 }
 
@@ -85,22 +90,26 @@ func exchangeAuthorizationCode(code string) (string, string) {
 		jsoniter.Get(data, "refresh_token").ToString()
 }
 
-func exchangeRefreshToken(code string) string {
+func exchangeRefreshToken(refreshToken string) string {
 	data := exchangeToken(url.Values{
-		"refresh_token": {code},
+		"refresh_token": {refreshToken},
 		"grant_type":    {"refresh_token"},
 	})
 	return jsoniter.Get(data, "access_token").ToString()
 }
 
 func exchangeToken(params url.Values) []byte {
-	params.Set("client_id", os.Getenv("SPOTIFY_CLIENT_ID"))
-	params.Set("client_secret", os.Getenv("SPOTIFY_CLIENT_SECRET"))
-	params.Set("redirect_uri", os.Getenv("SPOTIFY_REDIRECT_URI"))
+	form := url.Values{}
+	for k, v := range params {
+		form[k] = v
+	}
+	form.Set("client_id", os.Getenv("SPOTIFY_CLIENT_ID"))
+	form.Set("client_secret", os.Getenv("SPOTIFY_CLIENT_SECRET"))
+	form.Set("redirect_uri", os.Getenv("SPOTIFY_REDIRECT_URI"))
 
 	headers := http.Header{"Content-Type": {"application/x-www-form-urlencoded"}}
 	data, status := SendRequest(
-		http.MethodPost, spotifyTokenURL, headers, nil, strings.NewReader(params.Encode()),
+		http.MethodPost, spotifyTokenURL, headers, nil, strings.NewReader(form.Encode()),
 	)
 	if status != http.StatusOK {
 		fmt.Println(string(data))
@@ -127,7 +136,7 @@ func SendRequest(
 		request.Header = headers
 	}
 
-	response, err := http.DefaultClient.Do(request)
+	response, err := httpClient.Do(request)
 	HandleRequestError(err)
 	defer response.Body.Close()
 

--- a/cmd/spotify/auth/root_test.go
+++ b/cmd/spotify/auth/root_test.go
@@ -20,7 +20,7 @@ func TestSendRequest_GET_NoQueryNoBody(t *testing.T) {
 		gotPath = r.URL.Path
 		gotQuery = r.URL.RawQuery
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{"ok":true}`))
+		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer server.Close()
 

--- a/cmd/spotify/auth/root_test.go
+++ b/cmd/spotify/auth/root_test.go
@@ -1,0 +1,122 @@
+package auth
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSendRequest_GET_NoQueryNoBody(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotQuery  string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	data, status := SendRequest(http.MethodGet, server.URL+"/me", nil, nil, nil)
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("method = %q, want GET", gotMethod)
+	}
+	if gotPath != "/me" {
+		t.Errorf("path = %q, want /me", gotPath)
+	}
+	if gotQuery != "" {
+		t.Errorf("query = %q, want empty", gotQuery)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if string(data) != `{"ok":true}` {
+		t.Errorf("body = %q, want %q", string(data), `{"ok":true}`)
+	}
+}
+
+func TestSendRequest_QueryParamsEncoded(t *testing.T) {
+	var gotQuery url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	params := url.Values{"ids": {"abc"}, "market": {"US"}}
+	_, _ = SendRequest(http.MethodGet, server.URL+"/tracks", nil, params, nil)
+
+	if gotQuery.Get("ids") != "abc" {
+		t.Errorf("ids = %q, want abc", gotQuery.Get("ids"))
+	}
+	if gotQuery.Get("market") != "US" {
+		t.Errorf("market = %q, want US", gotQuery.Get("market"))
+	}
+}
+
+func TestSendRequest_HeadersAndBody(t *testing.T) {
+	var (
+		gotAuth        string
+		gotContentType string
+		gotBody        string
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	headers := Headers("token-123")
+	_, status := SendRequest(
+		http.MethodPut, server.URL+"/player", headers, nil, strings.NewReader(`{"x":1}`),
+	)
+
+	if gotAuth != "Bearer token-123" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer token-123")
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+	if gotBody != `{"x":1}` {
+		t.Errorf("body = %q, want %q", gotBody, `{"x":1}`)
+	}
+	if status != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", status)
+	}
+}
+
+func TestSendRequest_StatusCodePassthrough(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, status := SendRequest(http.MethodPut, server.URL, nil, nil, nil)
+	if status != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", status)
+	}
+}
+
+func TestHeaders_AllFieldsSet(t *testing.T) {
+	h := Headers("xyz")
+	if got := h.Get("Accept"); got != "application/json" {
+		t.Errorf("Accept = %q, want application/json", got)
+	}
+	if got := h.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+	if got := h.Get("Authorization"); got != "Bearer xyz" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer xyz")
+	}
+}

--- a/cmd/spotify/auth/root_test.go
+++ b/cmd/spotify/auth/root_test.go
@@ -97,12 +97,17 @@ func TestSendRequest_HeadersAndBody(t *testing.T) {
 }
 
 func TestSendRequest_StatusCodePassthrough(t *testing.T) {
+	var gotMethod string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer server.Close()
 
 	_, status := SendRequest(http.MethodPut, server.URL, nil, nil, nil)
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %q, want PUT", gotMethod)
+	}
 	if status != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", status)
 	}

--- a/cmd/spotify/root.go
+++ b/cmd/spotify/root.go
@@ -95,9 +95,13 @@ func alternateDeviceID(currentDeviceID string) string {
 }
 
 func currentDevice(accessToken string) string {
-	data, _ := auth.SendRequest(
+	data, status := auth.SendRequest(
 		http.MethodGet, spotifyDevicesURL, auth.Headers(accessToken), nil, nil,
 	)
+	if status >= http.StatusBadRequest {
+		log.Error("Failed to list devices (status %d)", status)
+		os.Exit(1)
+	}
 
 	const maxDevices = 10
 	for i := 0; i < maxDevices; i++ {
@@ -152,17 +156,28 @@ func removeTrack(accessToken string, trackID string) {
 // https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-tracks/
 func isTrackSaved(accessToken string, trackID string) bool {
 	params := url.Values{"ids": {trackID}}
-	data, _ := auth.SendRequest(
+	data, status := auth.SendRequest(
 		http.MethodGet, spotifyContainsURL, auth.Headers(accessToken), params, nil,
 	)
+	if status >= http.StatusBadRequest {
+		log.Error("Failed to check saved status (status %d)", status)
+		os.Exit(1)
+	}
 	return jsoniter.Get(data, 0).ToBool()
 }
 
 // https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/
 func currentTrackInfo(accessToken string) (string, string, string) {
-	data, _ := auth.SendRequest(
+	data, status := auth.SendRequest(
 		http.MethodGet, spotifyNowPlaying, auth.Headers(accessToken), nil, nil,
 	)
+	// Spotify returns 204 No Content when nothing is playing — treat that
+	// as "no current track" via the empty id below. Surface 4xx/5xx instead
+	// of silently parsing an error body.
+	if status >= http.StatusBadRequest {
+		log.Error("Failed to fetch currently-playing track (status %d)", status)
+		os.Exit(1)
+	}
 	id := jsoniter.Get(data, "item", "id").ToString()
 	name := jsoniter.Get(data, "item", "name").ToString()
 	artist := jsoniter.Get(data, "item", "artists", 0, "name").ToString()

--- a/cmd/spotify/root.go
+++ b/cmd/spotify/root.go
@@ -10,22 +10,25 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
 	"os"
 
 	"github.com/drn/dots/cmd/spotify/auth"
 	"github.com/drn/dots/pkg/log"
 	"github.com/drn/dots/pkg/path"
-	"github.com/imroc/req"
 	"github.com/joho/godotenv"
 	jsoniter "github.com/json-iterator/go"
 )
 
 const (
-	spotifyTracksURL    = "https://api.spotify.com/v1/me/tracks"
-	spotifyPlayerURL    = "https://api.spotify.com/v1/me/player"
-	spotifyDevicesURL   = "https://api.spotify.com/v1/me/player/devices"
-	spotifyNowPlaying   = "https://api.spotify.com/v1/me/player/currently-playing"
-	spotifyContainsURL  = "https://api.spotify.com/v1/me/tracks/contains"
+	spotifyTracksURL   = "https://api.spotify.com/v1/me/tracks"
+	spotifyPlayerURL   = "https://api.spotify.com/v1/me/player"
+	spotifyDevicesURL  = "https://api.spotify.com/v1/me/player/devices"
+	spotifyNowPlaying  = "https://api.spotify.com/v1/me/player/currently-playing"
+	spotifyContainsURL = "https://api.spotify.com/v1/me/tracks/contains"
 )
 
 func main() {
@@ -92,16 +95,17 @@ func alternateDeviceID(currentDeviceID string) string {
 }
 
 func currentDevice(accessToken string) string {
-	response, err := req.Get(spotifyDevicesURL, auth.Headers(accessToken))
-	auth.HandleRequestError(err)
+	data, _ := auth.SendRequest(
+		http.MethodGet, spotifyDevicesURL, auth.Headers(accessToken), nil, nil,
+	)
 
 	const maxDevices = 10
 	for i := 0; i < maxDevices; i++ {
-		id := jsoniter.Get(response.Bytes(), "devices", i, "id").ToString()
+		id := jsoniter.Get(data, "devices", i, "id").ToString()
 		if id == "" {
 			break
 		}
-		if jsoniter.Get(response.Bytes(), "devices", i, "is_active").ToBool() {
+		if jsoniter.Get(data, "devices", i, "is_active").ToBool() {
 			return id
 		}
 	}
@@ -109,11 +113,13 @@ func currentDevice(accessToken string) string {
 }
 
 func transferPlayback(accessToken string, deviceID string) {
-	json := req.BodyJSON(map[string]interface{}{"device_ids": []string{deviceID}})
-	response, err := req.Put(spotifyPlayerURL, auth.Headers(accessToken), json)
+	body, err := json.Marshal(map[string]interface{}{"device_ids": []string{deviceID}})
 	auth.HandleRequestError(err)
-	if response.Response().StatusCode != 204 {
-		println(response.Dump())
+	data, status := auth.SendRequest(
+		http.MethodPut, spotifyPlayerURL, auth.Headers(accessToken), nil, bytes.NewReader(body),
+	)
+	if status != http.StatusNoContent {
+		println(string(data))
 		log.Error("Failed to transfer device")
 		os.Exit(1)
 	}
@@ -121,10 +127,11 @@ func transferPlayback(accessToken string, deviceID string) {
 
 // https://developer.spotify.com/documentation/web-api/reference/library/save-tracks-user/
 func saveTrack(accessToken string, trackID string) {
-	params := req.QueryParam{"ids": trackID}
-	response, err := req.Put(spotifyTracksURL, auth.Headers(accessToken), params)
-	auth.HandleRequestError(err)
-	if response.Response().StatusCode != 200 {
+	params := url.Values{"ids": {trackID}}
+	_, status := auth.SendRequest(
+		http.MethodPut, spotifyTracksURL, auth.Headers(accessToken), params, nil,
+	)
+	if status != http.StatusOK {
 		log.Error("Failed to save track")
 		os.Exit(1)
 	}
@@ -132,10 +139,11 @@ func saveTrack(accessToken string, trackID string) {
 
 // https://developer.spotify.com/documentation/web-api/reference/library/remove-tracks-user/
 func removeTrack(accessToken string, trackID string) {
-	params := req.QueryParam{"ids": trackID}
-	response, err := req.Delete(spotifyTracksURL, auth.Headers(accessToken), params)
-	auth.HandleRequestError(err)
-	if response.Response().StatusCode != 200 {
+	params := url.Values{"ids": {trackID}}
+	_, status := auth.SendRequest(
+		http.MethodDelete, spotifyTracksURL, auth.Headers(accessToken), params, nil,
+	)
+	if status != http.StatusOK {
 		log.Error("Failed to remove track")
 		os.Exit(1)
 	}
@@ -143,21 +151,21 @@ func removeTrack(accessToken string, trackID string) {
 
 // https://developer.spotify.com/documentation/web-api/reference/library/check-users-saved-tracks/
 func isTrackSaved(accessToken string, trackID string) bool {
-	params := req.Param{"ids": trackID}
-	response, err := req.Get(spotifyContainsURL, auth.Headers(accessToken), params)
-	auth.HandleRequestError(err)
-
-	return jsoniter.Get(response.Bytes(), 0).ToBool()
+	params := url.Values{"ids": {trackID}}
+	data, _ := auth.SendRequest(
+		http.MethodGet, spotifyContainsURL, auth.Headers(accessToken), params, nil,
+	)
+	return jsoniter.Get(data, 0).ToBool()
 }
 
 // https://developer.spotify.com/documentation/web-api/reference/player/get-the-users-currently-playing-track/
 func currentTrackInfo(accessToken string) (string, string, string) {
-	response, err := req.Get(spotifyNowPlaying, auth.Headers(accessToken))
-	auth.HandleRequestError(err)
-	id := jsoniter.Get(response.Bytes(), "item", "id").ToString()
-	name := jsoniter.Get(response.Bytes(), "item", "name").ToString()
-	artist := jsoniter.Get(response.Bytes(), "item", "artists", 0, "name").ToString()
+	data, _ := auth.SendRequest(
+		http.MethodGet, spotifyNowPlaying, auth.Headers(accessToken), nil, nil,
+	)
+	id := jsoniter.Get(data, "item", "id").ToString()
+	name := jsoniter.Get(data, "item", "name").ToString()
+	artist := jsoniter.Get(data, "item", "artists", 0, "name").ToString()
 
 	return id, name, artist
 }
-

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/briandowns/spinner v1.11.1
 	github.com/fatih/color v1.10.0
 	github.com/go-ini/ini v1.62.0
-	github.com/imroc/req v0.3.0
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.10

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/imroc/req v0.3.0 h1:3EioagmlSG+z+KySToa+Ylo3pTFZs+jh3Brl7ngU12U=
-github.com/imroc/req v0.3.0/go.mod h1:F+NZ+2EFSo6EFXdeIbpfE9hcC233id70kf0byW97Caw=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=


### PR DESCRIPTION
Resolves Dependabot security alert GHSA-cj55-gc7m-wvcq (medium) on
github.com/imroc/req. The fix lives at a different Go module path
(req/v3) so Dependabot couldn't auto-upgrade — this was the only
failing job on master.

- Rewrite cmd/spotify/{auth/root.go,root.go} to use stdlib net/http +
  encoding/json + net/url. New shared helper auth.SendRequest.
- Bound HTTP client to a 10s timeout (http.DefaultClient is unbounded;
  old imroc/req shipped a 2-minute default).
- Fix latent refreshNeeded bug: PUT /v1/me always returned 405 so the
  401-based refresh check was a no-op. Switch to GET.
- Stop mutating caller-supplied url.Values in exchangeToken.
- Surface 4xx/5xx on read paths (currentDevice / isTrackSaved /
  currentTrackInfo) instead of silently parsing error bodies.
- Drop github.com/imroc/req from go.mod and go.sum entirely.
- Add httptest-backed unit tests for auth.SendRequest covering method,
  query encoding, headers, body forwarding, and status passthrough.

Co-Authored-By: Claude <noreply@anthropic.com>