### PR TITLE
Seed pi.dev default provider/model on install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ dots doctor                                   # Run diagnostics
 | tools | Devbox, Claude Code, Codex |
 | osx | macOS defaults |
 | agents | Agent skills, custom agents, hooks, and status line (symlinks agents/skills → ~/.claude/skills + ~/.agents/skills, agents/custom → ~/.claude/agents, registers hooks and status line in ~/.claude/settings.json) |
-| pi | pi.dev coding agent CLI + config (installs pi via curl pi.dev/install.sh, symlinks pi/agent/models.json → ~/.pi/agent/models.json; auth.json and sessions/ stay local) |
+| pi | pi.dev coding agent CLI + config (installs pi via curl pi.dev/install.sh, symlinks pi/agent/models.json → ~/.pi/agent/models.json, and seeds defaultProvider/defaultModel for Ollama qwen3:32b in ~/.pi/agent/settings.json; auth.json and sessions/ stay local) |
 
 ## Writing Skills / Slash Commands
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ dots docker stop-all     # Stop all Docker containers
 | `vim` | Vim/Neovim configuration with vim-plug and plugins |
 | `hammerspoon` | Lua-based window management and macOS automation |
 | `osx` | macOS system preferences and defaults |
-| `pi` | pi.dev coding agent CLI + config (installs `pi` via `curl pi.dev/install.sh`, symlinks `pi/agent/models.json` → `~/.pi/agent/models.json`; `auth.json` and `sessions/` stay local) |
+| `pi` | pi.dev coding agent CLI + config (installs `pi` via `curl pi.dev/install.sh`, symlinks `pi/agent/models.json` → `~/.pi/agent/models.json`, and seeds `defaultProvider`/`defaultModel` for Ollama qwen3:32b in `~/.pi/agent/settings.json`; `auth.json` and `sessions/` stay local) |
 
 ## Agent Skills
 

--- a/cli/commands/install/pi.go
+++ b/cli/commands/install/pi.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 
 	"github.com/drn/dots/cli/link"
 	"github.com/drn/dots/pkg/log"
@@ -40,7 +41,7 @@ func Pi() {
 	)
 
 	if err := seedPiSettings(path.FromHome(".pi/agent/settings.json")); err != nil {
-		log.Error("Failed to seed pi.dev settings: %s", err.Error())
+		log.Warning("Failed to seed pi.dev settings: %s", err.Error())
 	}
 }
 
@@ -55,21 +56,29 @@ func installPi() {
 // seedPiSettings ensures defaultProvider and defaultModel are set in pi.dev's
 // settings.json, merging into any existing content (e.g. lastChangelogVersion
 // written by pi.dev itself). Idempotent — a no-op when both fields already
-// match the seeded values.
+// match the seeded values. Writes atomically via tempfile + rename so a
+// concurrent pi.dev save can't observe a half-written file.
 func seedPiSettings(settingsPath string) error {
+	fileMode := os.FileMode(0600)
 	settings := map[string]any{}
+
 	data, err := os.ReadFile(settingsPath)
-	switch {
-	case err == nil:
+	if err == nil {
+		if info, statErr := os.Stat(settingsPath); statErr == nil {
+			fileMode = info.Mode().Perm()
+		}
 		if len(data) > 0 {
 			if err := json.Unmarshal(data, &settings); err != nil {
 				return err
 			}
 		}
-	case !errors.Is(err, os.ErrNotExist):
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 
+	// Idempotency check assumes both fields are strings when present, which is
+	// the schema pi.dev uses. A non-string value falls through and gets
+	// overwritten — desirable for a malformed schema.
 	if settings["defaultProvider"] == piDefaultProvider && settings["defaultModel"] == piDefaultModel {
 		return nil
 	}
@@ -80,5 +89,29 @@ func seedPiSettings(settingsPath string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(settingsPath, append(out, '\n'), 0644)
+	return writeFileAtomic(settingsPath, append(out, '\n'), fileMode)
+}
+
+// writeFileAtomic writes data to path via a sibling tempfile + rename so a
+// concurrent reader never observes a partial file.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }

--- a/cli/commands/install/pi.go
+++ b/cli/commands/install/pi.go
@@ -1,12 +1,19 @@
 package install
 
 import (
+	"encoding/json"
+	"errors"
 	"os"
 
 	"github.com/drn/dots/cli/link"
 	"github.com/drn/dots/pkg/log"
 	"github.com/drn/dots/pkg/path"
 	"github.com/drn/dots/pkg/run"
+)
+
+const (
+	piDefaultProvider = "ollama"
+	piDefaultModel    = "qwen3:32b"
 )
 
 // Pi - Installs pi.dev coding agent and configuration
@@ -31,6 +38,10 @@ func Pi() {
 		path.FromDots("pi/agent/models.json"),
 		path.FromHome(".pi/agent/models.json"),
 	)
+
+	if err := seedPiSettings(path.FromHome(".pi/agent/settings.json")); err != nil {
+		log.Error("Failed to seed pi.dev settings: %s", err.Error())
+	}
 }
 
 func installPi() {
@@ -39,4 +50,35 @@ func installPi() {
 		return
 	}
 	exec("curl -fsSL https://pi.dev/install.sh | sh")
+}
+
+// seedPiSettings ensures defaultProvider and defaultModel are set in pi.dev's
+// settings.json, merging into any existing content (e.g. lastChangelogVersion
+// written by pi.dev itself). Idempotent — a no-op when both fields already
+// match the seeded values.
+func seedPiSettings(settingsPath string) error {
+	settings := map[string]any{}
+	data, err := os.ReadFile(settingsPath)
+	switch {
+	case err == nil:
+		if len(data) > 0 {
+			if err := json.Unmarshal(data, &settings); err != nil {
+				return err
+			}
+		}
+	case !errors.Is(err, os.ErrNotExist):
+		return err
+	}
+
+	if settings["defaultProvider"] == piDefaultProvider && settings["defaultModel"] == piDefaultModel {
+		return nil
+	}
+	settings["defaultProvider"] = piDefaultProvider
+	settings["defaultModel"] = piDefaultModel
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(settingsPath, append(out, '\n'), 0644)
 }

--- a/cli/commands/install/pi_test.go
+++ b/cli/commands/install/pi_test.go
@@ -1,0 +1,153 @@
+package install
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSeedPiSettings_CreatesWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	got := readSettings(t, settingsPath)
+	if got["defaultProvider"] != piDefaultProvider {
+		t.Errorf("defaultProvider = %v, want %s", got["defaultProvider"], piDefaultProvider)
+	}
+	if got["defaultModel"] != piDefaultModel {
+		t.Errorf("defaultModel = %v, want %s", got["defaultModel"], piDefaultModel)
+	}
+}
+
+func TestSeedPiSettings_PreservesExistingFields(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	writeJSON(t, settingsPath, map[string]any{
+		"lastChangelogVersion": "0.74.0",
+		"steeringMode":         "auto",
+	})
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	got := readSettings(t, settingsPath)
+	if got["lastChangelogVersion"] != "0.74.0" {
+		t.Errorf("lastChangelogVersion = %v, want 0.74.0", got["lastChangelogVersion"])
+	}
+	if got["steeringMode"] != "auto" {
+		t.Errorf("steeringMode = %v, want auto", got["steeringMode"])
+	}
+	if got["defaultProvider"] != piDefaultProvider {
+		t.Errorf("defaultProvider = %v, want %s", got["defaultProvider"], piDefaultProvider)
+	}
+	if got["defaultModel"] != piDefaultModel {
+		t.Errorf("defaultModel = %v, want %s", got["defaultModel"], piDefaultModel)
+	}
+}
+
+func TestSeedPiSettings_IdempotentWhenAlreadySet(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	writeJSON(t, settingsPath, map[string]any{
+		"defaultProvider": piDefaultProvider,
+		"defaultModel":    piDefaultModel,
+	})
+
+	info, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat: %s", err)
+	}
+	mtime := info.ModTime()
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	after, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat: %s", err)
+	}
+	if !after.ModTime().Equal(mtime) {
+		t.Errorf("file rewritten when both defaults already match (mtime changed)")
+	}
+}
+
+func TestSeedPiSettings_OverwritesExistingDefaults(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	writeJSON(t, settingsPath, map[string]any{
+		"defaultProvider": "openai",
+		"defaultModel":    "gpt-5",
+	})
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	got := readSettings(t, settingsPath)
+	if got["defaultProvider"] != piDefaultProvider {
+		t.Errorf("defaultProvider = %v, want %s", got["defaultProvider"], piDefaultProvider)
+	}
+	if got["defaultModel"] != piDefaultModel {
+		t.Errorf("defaultModel = %v, want %s", got["defaultModel"], piDefaultModel)
+	}
+}
+
+func TestSeedPiSettings_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(settingsPath, nil, 0644); err != nil {
+		t.Fatalf("write empty file: %s", err)
+	}
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	got := readSettings(t, settingsPath)
+	if got["defaultProvider"] != piDefaultProvider || got["defaultModel"] != piDefaultModel {
+		t.Errorf("defaults not seeded into empty file: %v", got)
+	}
+}
+
+func TestSeedPiSettings_MalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte("{not json"), 0644); err != nil {
+		t.Fatalf("write malformed: %s", err)
+	}
+
+	if err := seedPiSettings(settingsPath); err == nil {
+		t.Error("expected error for malformed JSON, got nil")
+	}
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %s", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("write %s: %s", path, err)
+	}
+}
+
+func readSettings(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %s", path, err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %s", err)
+	}
+	return out
+}

--- a/cli/commands/install/pi_test.go
+++ b/cli/commands/install/pi_test.go
@@ -82,8 +82,9 @@ func TestSeedPiSettings_OverwritesExistingDefaults(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.json")
 	writeJSON(t, settingsPath, map[string]any{
-		"defaultProvider": "openai",
-		"defaultModel":    "gpt-5",
+		"defaultProvider":      "openai",
+		"defaultModel":         "gpt-5",
+		"lastChangelogVersion": "0.74.0",
 	})
 
 	if err := seedPiSettings(settingsPath); err != nil {
@@ -96,6 +97,68 @@ func TestSeedPiSettings_OverwritesExistingDefaults(t *testing.T) {
 	}
 	if got["defaultModel"] != piDefaultModel {
 		t.Errorf("defaultModel = %v, want %s", got["defaultModel"], piDefaultModel)
+	}
+	if got["lastChangelogVersion"] != "0.74.0" {
+		t.Errorf("lastChangelogVersion = %v, want 0.74.0 (preserved alongside overwrite)", got["lastChangelogVersion"])
+	}
+}
+
+func TestSeedPiSettings_PreservesFileMode(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	writeJSON(t, settingsPath, map[string]any{"lastChangelogVersion": "0.74.0"})
+	if err := os.Chmod(settingsPath, 0600); err != nil {
+		t.Fatalf("chmod: %s", err)
+	}
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	info, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat: %s", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("file mode = %o, want 0600", got)
+	}
+}
+
+func TestSeedPiSettings_CreatesWithRestrictiveMode(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	info, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat: %s", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("new file mode = %o, want 0600", got)
+	}
+}
+
+func TestSeedPiSettings_NonStringDefaults(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+	writeJSON(t, settingsPath, map[string]any{
+		"defaultProvider": 42,
+		"defaultModel":    true,
+	})
+
+	if err := seedPiSettings(settingsPath); err != nil {
+		t.Fatalf("seedPiSettings: %s", err)
+	}
+
+	got := readSettings(t, settingsPath)
+	if got["defaultProvider"] != piDefaultProvider {
+		t.Errorf("defaultProvider = %v, want %s (malformed value should be overwritten)", got["defaultProvider"], piDefaultProvider)
+	}
+	if got["defaultModel"] != piDefaultModel {
+		t.Errorf("defaultModel = %v, want %s (malformed value should be overwritten)", got["defaultModel"], piDefaultModel)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `dots install pi` now seeds `defaultProvider: "ollama"` and `defaultModel: "qwen3:32b"` into `~/.pi/agent/settings.json`, merging into any existing pi.dev-written fields (e.g. `lastChangelogVersion`) instead of clobbering them.
- Symlinking `settings.json` was rejected because pi.dev writes to it at runtime, which would constantly dirty the dotfiles worktree.

## Implementation notes
- New `seedPiSettings` in `cli/commands/install/pi.go` reads the existing JSON, overlays the two default keys, and writes atomically via tempfile + `os.Rename` so a concurrent pi.dev save can't observe a half-written file.
- Idempotent: returns early without rewriting when both fields already match — preserves mtime.
- File mode is preserved from the existing settings; new files are created at `0600` since the same directory holds `auth.json`.
- Malformed JSON surfaces as an error rather than silently clobbering pi.dev state.

## Test plan
- `go test ./cli/commands/install/...` — 8 unit tests covering create, preserve existing fields, idempotency, overwrite stale defaults, file mode preservation, restrictive mode on create, non-string defaults, empty file, and malformed JSON.
- Manual: `dots install pi` on a machine with an existing `~/.pi/agent/settings.json` containing `lastChangelogVersion` — verify both default keys appear and `lastChangelogVersion` is untouched.