### PR TITLE
Skip sandboxed repos in Argus capture hooks

### DIFF
--- a/agents/hooks/session-end-capture.sh
+++ b/agents/hooks/session-end-capture.sh
@@ -118,6 +118,14 @@ TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 [ -n "$CWD" ] || { STATUS="skip:no-cwd"; exit 0; }
 [ -d "$CWD" ] || { STATUS="skip:cwd-missing"; exit 0; }
 
+# Excluded repos must never be captured to the KB. Match by path segment, not
+# repo name: Conductor worktrees report their toplevel basename as the branch,
+# so the repo name only ever appears as a path component. This covers both the
+# source repo and its worktrees.
+case "$CWD" in
+  */trove|*/trove/*) STATUS="skip:excluded-repo"; exit 0 ;;
+esac
+
 # A session with no readable transcript is dead weight — there's no intent,
 # no excerpt, nothing to distill. Skip rather than write an empty stub.
 [ -n "$TRANSCRIPT" ] || { STATUS="skip:no-transcript-path"; exit 0; }

--- a/agents/hooks/track-kb-change.sh
+++ b/agents/hooks/track-kb-change.sh
@@ -24,6 +24,13 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+# Excluded repos must never be logged. Match by path segment — covers the
+# source repo and its worktrees. This also prevents kb_ingests run from an
+# excluded worktree from re-adding its cwd to the changelog.
+case "$CWD" in
+  */trove|*/trove/*) exit 0 ;;
+esac
+
 mkdir -p ~/.dots/sys/kb-changes ~/.dots/sys/dream-runs
 jq -nc --arg ts "$TS" --arg path "$KB_PATH" --arg session_id "$SESSION" --arg cwd "$CWD" \
   '{ts:$ts,path:$path,session_id:$session_id,cwd:$cwd}' \

--- a/agents/hooks/track-skill-use.sh
+++ b/agents/hooks/track-skill-use.sh
@@ -11,6 +11,13 @@ SESSION=$(echo "$INPUT" | jq -r '.session_id // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+# Excluded repos must never be logged. Match by path segment (worktrees report
+# the branch as their basename, so the repo name only appears as a path
+# component). Covers the source repo and its worktrees.
+case "$CWD" in
+  */trove|*/trove/*) exit 0 ;;
+esac
+
 mkdir -p ~/.dots/sys/skill-usage
 jq -nc --arg ts "$TS" --arg skill "$SKILL" --arg session_id "$SESSION" --arg cwd "$CWD" \
   '{ts:$ts,skill:$skill,session_id:$session_id,cwd:$cwd}' >> ~/.dots/sys/skill-usage/usage.jsonl


### PR DESCRIPTION
The three Argus capture hooks log every session/skill/kb-write along with the CWD. Add a path-segment guard to all three hooks so excluded (sandboxed) repos are skipped entirely.

Match by path segment (`*/trove|*/trove/*`) rather than repo name: Conductor worktrees report their branch as the toplevel basename, so the repo name only ever appears as a path component. The glob is precise — it won't match "mytrove" or "trove-utils". Covers both the source repo and its worktrees.

Co-Authored-By: Claude <noreply@anthropic.com>