### PR TITLE
Add slides skill for self-contained HTML presentation decks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,7 @@ When the user's message matches a phrase below, read and follow the correspondin
 | "explain like I'm 5", "eli5", "explain simply", "dumb it down", "explain in simple terms" | `agents/skills/eli5/SKILL.md` |
 | "skill usage", "which skills do I use", "unused skills", "skill stats", "skill suggestions" | `agents/skills/skill-usage/SKILL.md` |
 | "dream", "KB hygiene", "knowledge base cleanup", "memory hygiene", "audit KB", "dream consolidation" | `agents/skills/dream/SKILL.md` |
+| "create slides", "build a presentation", "make a deck", "turn talking points into a talk", "HTML slideshow", "presentation deck" | `agents/skills/slides/SKILL.md` |
 
 ## Public Repo Policy
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dots docker stop-all     # Stop all Docker containers
 
 ## Agent Skills
 
-Dots includes 66 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
+Dots includes 67 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
 
 | Skill | Description |
 |-------|-------------|
@@ -105,6 +105,7 @@ Dots includes 66 reusable slash-command skills for AI coding agents, following t
 | `/dream` | Ingest meetings + session captures into the inbox, synthesize raw notes into existing topical docs, and audit KB hygiene — frontmatter, sizing, naming |
 | `/retro` | Structured retrospective or post-incident review |
 | `/logo` | Logo generation |
+| `/slides` | Build a self-contained HTML presentation deck from talking points or a doc, with keyboard, tap, and swipe navigation |
 | `/improve` | Improve skills, capture context and knowledge |
 | `/rereview` | Re-review with fresh eyes, zero regressions |
 | `/rereview-loop` | Run `/rereview`, fix the findings, and loop until reviewers approve clean |
@@ -189,7 +190,7 @@ Run `dots install agents` to symlink them to `~/.claude/agents/`.
 ├── pi/                        # pi.dev coding agent config (models.json only)
 │
 ├── agents/                    # Agent configuration
-│   ├── skills/                # 66 reusable skills (SKILL.md per skill)
+│   ├── skills/                # 67 reusable skills (SKILL.md per skill)
 │   └── custom/                # 3 custom agent types (.md per agent)
 │       └── tests/             # Skill test suite
 │

--- a/agents/skills/slides/SKILL.md
+++ b/agents/skills/slides/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: slides
+description: Build a self-contained, single-file HTML presentation deck from talking points or a source doc, using a terminal/TUI-styled template with keyboard, tap, and swipe navigation. Use when the user wants to create slides, build a presentation or deck, turn talking points or a doc into a talk, make an HTML slideshow, or produce a presentation as a shareable artifact (instead of Google Slides).
+---
+
+# HTML Presentation Deck
+
+Generate a polished, single-file HTML slide deck from a `template.html` baseline.
+No build step — all CSS and JS are inline, so the deck opens directly in a
+browser and renders as an Argus artifact on desktop and phone.
+
+The template ships a terminal/TUI aesthetic (dark background, accent color,
+monospace + serif fonts) and a full navigation model: keyboard, an overview
+grid, a help overlay, URL-hash sync, a progress bar, plus mobile tap-to-advance
+and swipe. Preserve all of that — you change content and theme, not the nav JS.
+
+## When to stop and ask
+
+If the request is vague ("make me some slides"), ask the user for:
+- the talk's topic and audience, and
+- source material (a doc, bullet list, or talking points), or whether you should draft an outline first.
+
+Do not invent a whole talk from nothing.
+
+## Workflow
+
+### Step 1 — Gather source and set up the deck
+
+1. Collect the source content: a doc, talking points, or an outline the user provides.
+2. Choose a destination directory for the deck (default: a `presentation/` folder
+   the user names, or alongside the source material). Decks are talk material,
+   not product code — do not commit a deck into an unrelated repo.
+3. Copy the template into place:
+   ```
+   cp <skill-dir>/template.html <dest>/index.html
+   ```
+   `<skill-dir>` is the directory containing this SKILL.md.
+
+### Step 2 — Set the theme and chrome
+
+Edit the top of `index.html`:
+- `<title>` — browser tab text.
+- The `:root` block — colors and fonts. The defaults are a terminal look; change
+  `--teal` (accent), `--bg`, and `--mono`/`--serif` to re-skin. See `references/theme.md`.
+- `.frame .tab` — the window-tab label (short).
+- `.statusbar .branch` — the context/branch label.
+
+To swap fonts, also update the Google Fonts `<link>` in `<head>`. If the deck must
+work fully offline, see the self-host note in `references/theme.md`.
+
+### Step 3 — Write the slides
+
+Replace the example `<section class="slide ...">` blocks in `<main class="deck">`
+with the real content. Each slide is one of six archetypes: `title`, `big`,
+`divider`, `list`, `shot`, `question`. Read `references/archetypes.md` for the
+exact markup of each, and `references/content-guide.md` for the narrative rules
+(one idea per slide, minimal text, more slides less text, questions as slides,
+big statements, no name-dropping as proof, factual precision on technical claims).
+
+Verify any specific technical claim (security boundaries, numbers, what a system
+does) against the source before it goes on a slide.
+
+### Step 4 — Update the SECTIONS array (critical)
+
+The status bar shows a section label derived from a hand-maintained array in the
+`<script>`:
+```
+const SECTIONS = [ [firstSlideNumber, "label"], ... ];
+```
+Each entry maps a section's FIRST slide number (1-indexed) to its label.
+
+**This is the number-one footgun.** Adding or removing any slide shifts every
+later slide number by ±1, so the labels — and the divider `01`/`02`/… numbers —
+desync silently. After ANY structural change to the slide list:
+1. Recount the slides in document order.
+2. Re-derive each section's first-slide number and update `SECTIONS`.
+3. Confirm each `divider` `.num` matches its section position.
+
+The `slide N/M` total auto-updates from `slides.length` at runtime, so ignore the
+static `id="total"` value in the HTML — the JS overwrites it.
+
+### Step 5 — QA every slide type
+
+1. Open the deck locally to eyeball it:
+   ```
+   open <dest>/index.html
+   ```
+2. For automated screenshot QA, drive it with Playwright and read the images
+   back. Capture at least one slide of each archetype used. Verify:
+   - the section label in the status bar is correct on each section's first slide,
+   - the `slide N/M` total equals the real slide count,
+   - divider numbers are sequential,
+   - screenshots render and are not cut off.
+
+   IMPORTANT: run Playwright from a directory where it is installed (a `web-tests/`
+   or similar with `npm ci` already done), not from an arbitrary repo root, or it
+   throws `Cannot find module 'playwright'`. `cd` into that directory first and
+   point the script at the deck's absolute path.
+
+Fix any desync found here by returning to Step 4.
+
+### Step 6 — Register as an Argus artifact (optional, for mobile viewing)
+
+The on-disk deck references screenshots by relative path, but the artifact viewer
+sandbox has no relative-asset guarantee. Inline the images into a self-contained
+copy first, then register that copy:
+1. Produce an inlined copy:
+   ```
+   python3 <skill-dir>/scripts/inline-images.py <dest>/index.html /tmp/deck.inlined.html
+   ```
+   This base64-encodes every local `<img>` into a data URI.
+2. Register `/tmp/deck.inlined.html` via the Argus `artifact_register` tool.
+3. Re-run both steps after every edit — registration is last-write-wins on the
+   same title.
+
+If the artifact sandbox blocks network, the Google-fonts dependency falls back to
+system serif/mono (layout unaffected, look degraded). For a fully offline deck,
+self-host or inline the fonts — see `references/theme.md`.
+
+## Done criteria
+
+- `index.html` opens in a browser and navigates with arrows, `o`, `?`, tap, and swipe.
+- Every slide is one of the six archetypes; no slide is a wall of text.
+- `SECTIONS` and divider numbers match the actual slide order.
+- The `slide N/M` total matches the real count.
+- Every technical claim on a slide is verified against the source.
+
+## Files
+
+- `template.html` — the baseline deck (theme block at top, slides in `<main>`, nav JS at bottom).
+- `references/archetypes.md` — markup for each of the six slide archetypes.
+- `references/content-guide.md` — narrative and text conventions.
+- `references/theme.md` — theming variables and offline-font notes.
+- `scripts/inline-images.py` — base64-inline images for artifact registration.

--- a/agents/skills/slides/SKILL.md
+++ b/agents/skills/slides/SKILL.md
@@ -27,9 +27,10 @@ Do not invent a whole talk from nothing.
 ### Step 1 — Gather source and set up the deck
 
 1. Collect the source content: a doc, talking points, or an outline the user provides.
-2. Choose a destination directory for the deck (default: a `presentation/` folder
-   the user names, or alongside the source material). Decks are talk material,
-   not product code — do not commit a deck into an unrelated repo.
+2. Choose a destination directory for the deck. Decks are talk material, not
+   product code — do not commit one into an unrelated code repo. Good defaults:
+   a `presentation/` folder the user names, alongside the source material, or
+   `~/presentations/<talk-slug>/`.
 3. Copy the template into place:
    ```
    cp <skill-dir>/template.html <dest>/index.html
@@ -42,8 +43,8 @@ Edit the top of `index.html`:
 - `<title>` — browser tab text.
 - The `:root` block — colors and fonts. The defaults are a terminal look; change
   `--teal` (accent), `--bg`, and `--mono`/`--serif` to re-skin. See `references/theme.md`.
-- `.frame .tab` — the window-tab label (short).
-- `.statusbar .branch` — the context/branch label.
+- The window-tab label and the status-bar context label — both marked with
+  `<!-- EDIT: ... -->` comments in the HTML body. Keep them short.
 
 To swap fonts, also update the Google Fonts `<link>` in `<head>`. If the deck must
 work fully offline, see the self-host note in `references/theme.md`.
@@ -60,21 +61,19 @@ big statements, no name-dropping as proof, factual precision on technical claims
 Verify any specific technical claim (security boundaries, numbers, what a system
 does) against the source before it goes on a slide.
 
-### Step 4 — Update the SECTIONS array (critical)
+### Step 4 — Set section labels and divider numbers
 
-The status bar shows a section label derived from a hand-maintained array in the
-`<script>`:
-```
-const SECTIONS = [ [firstSlideNumber, "label"], ... ];
-```
-Each entry maps a section's FIRST slide number (1-indexed) to its label.
-
-**This is the number-one footgun.** Adding or removing any slide shifts every
-later slide number by ±1, so the labels — and the divider `01`/`02`/… numbers —
-desync silently. After ANY structural change to the slide list:
-1. Recount the slides in document order.
-2. Re-derive each section's first-slide number and update `SECTIONS`.
-3. Confirm each `divider` `.num` matches its section position.
+The status bar shows a section label that holds from the slide opening a section
+until the next one. Sections are declared inline with a `data-section="..."`
+attribute on the slide that OPENS each section, and the `<script>` derives the
+label list from the DOM at load — so adding or removing slides never desyncs the
+labels. To structure the deck:
+1. Put `data-section="label"` on the FIRST slide of each section (the opening
+   `title`, each `divider`, and any mid-deck transition you want labelled). The
+   very first slide must carry one, or early slides show a blank label.
+2. The divider `.num` values (`01`, `02`, …) are still hand-written — keep them
+   sequential and matching the section order. This is the one remaining manual
+   sync, so check it after reordering sections.
 
 The `slide N/M` total auto-updates from `slides.length` at runtime, so ignore the
 static `id="total"` value in the HTML — the JS overwrites it.
@@ -99,29 +98,34 @@ static `id="total"` value in the HTML — the JS overwrites it.
 
 Fix any desync found here by returning to Step 4.
 
-### Step 6 — Register as an Argus artifact (optional, for mobile viewing)
+### Step 6 — Publish as a shareable artifact (optional, for mobile viewing)
 
-The on-disk deck references screenshots by relative path, but the artifact viewer
+The primary deliverable is the self-contained `index.html` — it opens in any
+browser as-is. This step is only for viewers that render a registered artifact
+(such as Argus, for viewing on a phone).
+
+The on-disk deck references screenshots by relative path, but an artifact viewer
 sandbox has no relative-asset guarantee. Inline the images into a self-contained
 copy first, then register that copy:
-1. Produce an inlined copy:
+1. Produce an inlined copy (writes to the system temp dir by default):
    ```
-   python3 <skill-dir>/scripts/inline-images.py <dest>/index.html /tmp/deck.inlined.html
+   python3 <skill-dir>/scripts/inline-images.py <dest>/index.html
    ```
-   This base64-encodes every local `<img>` into a data URI.
-2. Register `/tmp/deck.inlined.html` via the Argus `artifact_register` tool.
-3. Re-run both steps after every edit — registration is last-write-wins on the
-   same title.
+   This base64-encodes every local `<img>` into a data URI and prints the output path.
+2. Register the inlined copy via your artifact tool (e.g. the Argus
+   `artifact_register` tool, if available).
+3. Re-run both steps after every edit — registration is typically last-write-wins
+   on the same title.
 
-If the artifact sandbox blocks network, the Google-fonts dependency falls back to
-system serif/mono (layout unaffected, look degraded). For a fully offline deck,
-self-host or inline the fonts — see `references/theme.md`.
+If the sandbox blocks network, the Google-fonts dependency falls back to system
+serif/mono (layout unaffected, look degraded). For a fully offline deck, self-host
+or inline the fonts — see `references/theme.md`.
 
 ## Done criteria
 
 - `index.html` opens in a browser and navigates with arrows, `o`, `?`, tap, and swipe.
 - Every slide is one of the six archetypes; no slide is a wall of text.
-- `SECTIONS` and divider numbers match the actual slide order.
+- Section labels (`data-section`) and divider numbers match the actual slide order.
 - The `slide N/M` total matches the real count.
 - Every technical claim on a slide is verified against the source.
 

--- a/agents/skills/slides/references/archetypes.md
+++ b/agents/skills/slides/references/archetypes.md
@@ -1,0 +1,105 @@
+# Slide Archetypes
+
+Every slide is a `<section class="slide ARCHETYPE">` inside `<main class="deck">`.
+There are six archetypes. Pick the one that fits the idea — do not invent new
+classes unless you also add matching CSS to the theme block.
+
+## title
+
+The opening slide. One per deck, first.
+
+```html
+<section class="slide title">
+  <div class="boot">
+    <span class="ok">●</span> a scene-setting status line<br>
+    <span class="ok">●</span> another line
+  </div>
+  <h1>Talk Title<br>With an <em>emphasis</em></h1>
+  <div class="sub">Subtitle · <b>Event</b> · Month Year</div>
+</section>
+```
+
+- `.boot` is an optional flavor block (terminal-style status lines). Drop it for a cleaner title.
+- `<em>` inside `h1` renders in the accent color + italic serif.
+- `.sub` is an uppercase, letter-spaced footer line; `<b>` inside it is amber.
+
+## big
+
+A single bold statement. The workhorse for impact slides. One idea, no bullets.
+
+```html
+<section class="slide big">
+  <div class="crumb">section crumb</div>
+  <h1>One bold line with an <em>emphasized</em> phrase.<span class="cursor"></span></h1>
+</section>
+```
+
+- `.crumb` is an optional uppercase breadcrumb above the statement.
+- `.cursor` is an optional blinking block cursor — use sparingly, e.g. a punchy reveal.
+- Keep `h1` to roughly one sentence. If it reads like a paragraph, split it into two `big` slides.
+
+## divider
+
+A section opener with a huge outlined number.
+
+```html
+<section class="slide divider">
+  <div class="num">01</div>
+  <h1>Section name</h1>
+  <div class="rule"></div>
+  <!-- optional framing crumb under the rule: -->
+  <div class="crumb" style="margin:3vh 0 0">a one-line framing note</div>
+</section>
+```
+
+- `.num` is the section number. **It is hand-written** — keep 01/02/03… in order and in sync with the `SECTIONS` array (see SKILL.md "SECTIONS maintenance").
+- `.rule` is the glowing accent underline.
+
+## list
+
+Up to ~5 bullets. One concept per slide; 5 points is often 5 slides, not one dense list.
+
+```html
+<section class="slide list">
+  <h1>List slide title</h1>
+  <ul>
+    <li><b>Accent key</b> — supporting detail</li>
+    <li>A point with a <span class="x">negative</span> callout</li>
+    <li>A point with a <span class="ok">positive</span> callout</li>
+  </ul>
+</section>
+```
+
+- `<b>` = teal accent key (lead term). `.x` = red/warning. `.ok` = green/positive.
+- Hard cap at 5 `<li>`. More than that means the slide is doing two jobs — split it.
+
+## shot
+
+A screenshot inside a macOS-style window frame.
+
+```html
+<section class="slide shot">
+  <h1>Screenshot slide title</h1>
+  <div class="win">
+    <div class="bar"><i></i><i></i><i></i></div>
+    <img src="screenshot.png" alt="Describe the screenshot">
+  </div>
+</section>
+```
+
+- `src` is a relative path beside the HTML. Always write a real `alt`.
+- The three `.bar i` dots are the red/amber/green traffic lights — leave them.
+- Use real product screenshots, not stock imagery.
+
+## question
+
+A centered italic closing question.
+
+```html
+<section class="slide question">
+  <h1>A rhetorical closing question with a <span class="hl">highlight</span>?</h1>
+</section>
+```
+
+- `.hl` highlights a phrase in the accent color.
+- Typically the last slide.

--- a/agents/skills/slides/references/archetypes.md
+++ b/agents/skills/slides/references/archetypes.md
@@ -9,7 +9,7 @@ classes unless you also add matching CSS to the theme block.
 The opening slide. One per deck, first.
 
 ```html
-<section class="slide title">
+<section class="slide title" data-section="opening">
   <div class="boot">
     <span class="ok">●</span> a scene-setting status line<br>
     <span class="ok">●</span> another line
@@ -19,6 +19,7 @@ The opening slide. One per deck, first.
 </section>
 ```
 
+- `data-section` is required on this first slide, or early slides show a blank status-bar label (see SKILL.md Step 4).
 - `.boot` is an optional flavor block (terminal-style status lines). Drop it for a cleaner title.
 - `<em>` inside `h1` renders in the accent color + italic serif.
 - `.sub` is an uppercase, letter-spaced footer line; `<b>` inside it is amber.
@@ -43,7 +44,7 @@ A single bold statement. The workhorse for impact slides. One idea, no bullets.
 A section opener with a huge outlined number.
 
 ```html
-<section class="slide divider">
+<section class="slide divider" data-section="01 · section name">
   <div class="num">01</div>
   <h1>Section name</h1>
   <div class="rule"></div>
@@ -52,7 +53,8 @@ A section opener with a huge outlined number.
 </section>
 ```
 
-- `.num` is the section number. **It is hand-written** — keep 01/02/03… in order and in sync with the `SECTIONS` array (see SKILL.md "SECTIONS maintenance").
+- `data-section="..."` sets the status-bar label that holds from this slide until the next `data-section` (see SKILL.md Step 4). Put it on the slide that opens a section.
+- `.num` is the section number. **It is hand-written** — keep 01/02/03… in order, matching the section sequence.
 - `.rule` is the glowing accent underline.
 
 ## list

--- a/agents/skills/slides/references/content-guide.md
+++ b/agents/skills/slides/references/content-guide.md
@@ -1,0 +1,54 @@
+# Content & Narrative Conventions
+
+These are reusable presentation conventions for building a talk deck. They are
+about *what goes on a slide*, not *how it is styled* (that is archetypes.md).
+
+## Core principles
+
+1. **One idea per slide.** Never put two concepts on the same slide. Five points
+   is five slides, not one dense list.
+2. **Minimal text.** One or two sentences max. If a slide reads like a paragraph,
+   split it.
+3. **More slides, less text.** A 5-minute section is 10–15 slides, not 3–5 dense
+   ones — roughly 20–30 seconds per slide.
+4. **Questions as slides.** A rhetorical question makes a strong standalone slide,
+   especially as a section or talk close.
+5. **Big-number / big-statement slides.** A single bold claim on its own slide
+   (the `big` archetype) lands harder than the same claim buried in a bullet.
+
+## Mapping ideas to archetypes
+
+- Opening → `title`
+- A claim or pivot you want to land → `big`
+- Entering a new section → `divider` (with sequential 01/02/… numbers)
+- A short enumerated set (≤5) → `list`
+- Showing the actual thing → `shot`
+- Closing the talk or a section → `question`
+
+## Text rules
+
+- **Titles:** short and punchy, roughly ≤8 words.
+- **Bullets:** fragments, not full sentences. Bold only the lead term / key name.
+- **Emphasis:** use `<em>` (big/title) or `<b>` (lists) for the one word that
+  carries the point — not whole clauses.
+- **Closing:** an italic rhetorical question, or a short imperative.
+
+## Argument hygiene
+
+- **No name-dropping as proof.** Do not list people or teams as social proof
+  ("it's already happening"). The argument should stand on its own conviction.
+- **No third-party examples as proof.** Do not cite outside companies or industry
+  trends to justify a point — argue what the audience should do, not what others do.
+- **Do not front-load the payoff.** Avoid an early slide that spoils the close.
+- **Factual precision on technical claims.** Verify any specific technical claim
+  (security boundaries, performance numbers, what a system actually does) against
+  the source before it goes on a slide. A precise, smaller claim beats an
+  impressive, false one.
+- **Plain voice.** No cheeky sign-offs, no dramatic phrasing. State it plainly.
+
+## What not to do
+
+- No paragraphs on a slide.
+- No more than 5 bullets per slide.
+- No multiple distinct quotes/ideas on one slide.
+- No stock photos — real screenshots or no image.

--- a/agents/skills/slides/references/theme.md
+++ b/agents/skills/slides/references/theme.md
@@ -1,0 +1,58 @@
+# Theming
+
+The aesthetic is swappable. Everything visual lives in the `:root` block and the
+`<head>` font link of `template.html` — the slide markup and nav JS are theme-agnostic.
+
+## Color and font variables
+
+In `:root`:
+
+| Variable | Role | Default (terminal/TUI) |
+|----------|------|------------------------|
+| `--bg` | page background | `#07090f` |
+| `--bg-raise` | raised surfaces (status bar, window frames) | `#0c1018` |
+| `--ink` | primary text | `#e8edf2` |
+| `--dim` | secondary text | `#5c6878` |
+| `--faint` | borders, rules | `#2a3240` |
+| `--teal` | ACCENT — emphasis, keys, progress | `#19c2bd` |
+| `--teal-dark` | muted accent (divider numbers) | `#0c615e` |
+| `--amber` | warm highlight (branch label) | `#e8b04b` |
+| `--red` | warning / negative (`.x`) | `#e0556a` |
+| `--green` | positive / ok (`.ok`) | `#5dd39e` |
+| `--mono` | body font | JetBrains Mono |
+| `--serif` | display font (headings) | Instrument Serif |
+
+To re-skin: change `--teal` (the accent that ties the deck together), then
+`--bg`/`--ink` for the base palette. The accent also appears hard-coded in a few
+`rgba(25,194,189,...)` glows (progress bar, divider rule, screenshot shadow) — if
+you change `--teal` to a very different hue, update those rgba values to match.
+
+## Swapping fonts
+
+1. Replace the Google Fonts `<link>` in `<head>` with the families you want.
+2. Update `--mono` and `--serif` in `:root` to reference them.
+
+The display font (`--serif`) carries most of the character — it renders all the
+`h1` headings. The body font (`--mono`) renders bullets, crumbs, and chrome.
+
+## Offline / no-network decks
+
+The template loads fonts from `fonts.googleapis.com`. If the deck must render
+where network is blocked (some artifact sandboxes), it falls back to system
+serif/mono — layout is unaffected, but the look degrades.
+
+For a fully self-contained, offline deck:
+- Download the font files (woff2) and embed them as base64 `@font-face` rules in
+  the `<style>` block, dropping the `<link>`, or
+- Accept the system-font fallback and pick `--mono`/`--serif` stacks that look
+  acceptable without the web fonts.
+
+Images are made offline-safe separately, by `scripts/inline-images.py` (see SKILL.md Step 6).
+
+## Lighter / non-terminal looks
+
+The scanline, grain, and vignette overlays create the CRT/terminal feel. To move
+toward a clean modern look:
+- Remove or reduce `body::before` (scanlines) and the `.grain` element.
+- Soften `body::after` (vignette) or remove it.
+- Flip `--bg`/`--ink` for a light theme and lower the glow `rgba` alphas.

--- a/agents/skills/slides/scripts/inline-images.py
+++ b/agents/skills/slides/scripts/inline-images.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Inline an HTML deck's relative <img src="..."> assets as base64 data URIs.
+
+The on-disk deck references screenshots by relative path. The Argus artifact
+viewer sandbox has no relative-asset guarantee, so a self-contained copy is
+needed before artifact_register. This reads each local image referenced in the
+HTML, base64-encodes it, and rewrites src="name.png" -> src="data:...;base64,...".
+
+Usage:
+    python3 inline-images.py <input.html> [output.html]
+
+Defaults output to /tmp/<input-stem>.inlined.html. Prints the output path.
+"""
+import base64
+import mimetypes
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+
+def inline(input_path: Path, output_path: Path) -> None:
+    html = input_path.read_text(encoding="utf-8")
+    base_dir = input_path.parent
+
+    def repl(match: re.Match) -> str:
+        quote, src = match.group(1), match.group(2)
+        # Skip already-inlined data URIs and remote URLs.
+        if src.startswith(("data:", "http://", "https://", "//")):
+            return match.group(0)
+        asset = (base_dir / src).resolve()
+        if not asset.is_file():
+            print(f"  warn: asset not found, leaving as-is: {src}", file=sys.stderr)
+            return match.group(0)
+        mime = mimetypes.guess_type(asset.name)[0] or "application/octet-stream"
+        b64 = base64.b64encode(asset.read_bytes()).decode("ascii")
+        print(f"  inlined {src} ({len(b64)} b64 chars)", file=sys.stderr)
+        return f'src={quote}data:{mime};base64,{b64}{quote}'
+
+    html = re.sub(r'src=(["\'])([^"\']+)\1', repl, html)
+    output_path.write_text(html, encoding="utf-8")
+    print(output_path)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 1
+    input_path = Path(sys.argv[1]).resolve()
+    if not input_path.is_file():
+        print(f"error: input not found: {input_path}", file=sys.stderr)
+        return 1
+    if len(sys.argv) >= 3:
+        output_path = Path(sys.argv[2]).resolve()
+    else:
+        output_path = Path(tempfile.gettempdir()) / f"{input_path.stem}.inlined.html"
+    inline(input_path, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agents/skills/slides/scripts/inline-images.py
+++ b/agents/skills/slides/scripts/inline-images.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Inline an HTML deck's relative <img src="..."> assets as base64 data URIs.
 
-The on-disk deck references screenshots by relative path. The Argus artifact
-viewer sandbox has no relative-asset guarantee, so a self-contained copy is
-needed before artifact_register. This reads each local image referenced in the
+The on-disk deck references screenshots by relative path. An artifact viewer
+sandbox (e.g. Argus) has no relative-asset guarantee, so a self-contained copy
+is needed before registering it. This reads each local image referenced in the
 HTML, base64-encodes it, and rewrites src="name.png" -> src="data:...;base64,...".
+Only <img> src attributes are rewritten, and only assets inside the deck's own
+directory (paths that escape via ../ are refused).
 
 Usage:
     python3 inline-images.py <input.html> [output.html]
@@ -23,21 +25,30 @@ def inline(input_path: Path, output_path: Path) -> None:
     html = input_path.read_text(encoding="utf-8")
     base_dir = input_path.parent
 
+    base_resolved = base_dir.resolve()
+
     def repl(match: re.Match) -> str:
-        quote, src = match.group(1), match.group(2)
+        quote, src = match.group(2), match.group(3)
         # Skip already-inlined data URIs and remote URLs.
         if src.startswith(("data:", "http://", "https://", "//")):
             return match.group(0)
         asset = (base_dir / src).resolve()
+        # Containment: refuse paths that escape the deck directory (e.g. ../../id_rsa).
+        # src comes from HTML that may be agent-generated from untrusted source content.
+        if base_resolved not in asset.parents and asset != base_resolved:
+            print(f"  warn: refusing path outside deck dir, leaving as-is: {src}", file=sys.stderr)
+            return match.group(0)
         if not asset.is_file():
             print(f"  warn: asset not found, leaving as-is: {src}", file=sys.stderr)
             return match.group(0)
+        # MIME is inferred from the file extension, not magic bytes — fine for deck images.
         mime = mimetypes.guess_type(asset.name)[0] or "application/octet-stream"
         b64 = base64.b64encode(asset.read_bytes()).decode("ascii")
         print(f"  inlined {src} ({len(b64)} b64 chars)", file=sys.stderr)
-        return f'src={quote}data:{mime};base64,{b64}{quote}'
+        return f'<img{match.group(1)} src={quote}data:{mime};base64,{b64}{quote}'
 
-    html = re.sub(r'src=(["\'])([^"\']+)\1', repl, html)
+    # Scope to <img> tags only — avoid touching <script src>, <iframe src>, etc.
+    html = re.sub(r'<img([^>]*?)\ssrc=(["\'])([^"\']+)\2', repl, html)
     output_path.write_text(html, encoding="utf-8")
     print(output_path)
 

--- a/agents/skills/slides/template.html
+++ b/agents/skills/slides/template.html
@@ -27,6 +27,9 @@
   --green: #5dd39e;       /* positive / ok (.ok) */
   --mono: "JetBrains Mono", ui-monospace, monospace;  /* body font */
   --serif: "Instrument Serif", Georgia, serif;        /* display font (headings) */
+  /* NOTE: the accent also appears as hard-coded rgba(25,194,189,...) glows below
+     (progress bar, divider rule, screenshot shadow). If you change --teal to a
+     very different hue, update those rgba values to match. */
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 html, body { height: 100%; overflow: hidden; background: var(--bg); }
@@ -271,8 +274,9 @@ body::after {             /* vignette + accent glow */
      ════════════════════════════════════════════════════════════════ -->
 <main class="deck" id="deck">
 
-  <!-- 1 · title -->
-  <section class="slide title">
+  <!-- 1 · title.  data-section opens a section: its label shows in the status
+       bar from here until the next data-section. Sections are derived at runtime. -->
+  <section class="slide title" data-section="opening">
     <div class="boot">
       <span class="ok">●</span> line one — a scene-setting status line<br>
       <span class="ok">●</span> line two<br>
@@ -288,8 +292,8 @@ body::after {             /* vignette + accent glow */
     <h1>A single bold statement with one <em>emphasized</em> phrase.<span class="cursor"></span></h1>
   </section>
 
-  <!-- 3 · divider — section opener. KEEP num in sync with SECTIONS below. -->
-  <section class="slide divider">
+  <!-- 3 · divider — section opener. The .num is hand-written: keep 01/02/… sequential. -->
+  <section class="slide divider" data-section="01 · first section">
     <div class="num">01</div>
     <h1>First section</h1>
     <div class="rule"></div>
@@ -315,7 +319,7 @@ body::after {             /* vignette + accent glow */
   </section>
 
   <!-- 6 · question — centered italic close -->
-  <section class="slide question">
+  <section class="slide question" data-section="close">
     <h1>A closing rhetorical question with a <span class="hl">highlight</span>?</h1>
   </section>
 
@@ -330,7 +334,7 @@ body::after {             /* vignette + accent glow */
   <span class="sep"></span>
   <!-- id="total" is overwritten at runtime from slides.length — static value is a placeholder -->
   <span class="cell count">slide <b id="cur">1</b><span class="dim">/</span><b id="total">6</b></span>
-  <span class="cell keys keys-right">​<b>←→</b> navigate&nbsp;&nbsp;<b>o</b> overview&nbsp;&nbsp;<b>?</b> help</span>
+  <span class="cell keys keys-right"><b>←→</b> navigate&nbsp;&nbsp;<b>o</b> overview&nbsp;&nbsp;<b>?</b> help</span>
 </div>
 
 <div class="help" id="help">
@@ -356,16 +360,15 @@ const secEl  = document.getElementById("section");
 const help   = document.getElementById("help");
 
 /* ════════════════════════════════════════════════════════════════
-   SECTIONS — maps each section's FIRST slide number (1-indexed) to the
-   status-bar label shown for that range.  CRITICAL: when you add or
-   remove a slide, every later index shifts by ±1 — re-derive these
-   numbers or the labels (and divider 01/02/… numbers) silently desync.
+   SECTIONS — derived from data-section="..." attributes on the slides
+   that OPEN each section. Building it from the DOM at load means adding
+   or removing slides never desyncs the status-bar labels. (Divider .num
+   values 01/02/… are still hand-written — keep them sequential.)
    ════════════════════════════════════════════════════════════════ */
-const SECTIONS = [
-  [1,"opening"],
-  [3,"01 · first section"],
-  [6,"close"]
-];
+const SECTIONS = slides.reduce((acc, s, k) => {
+  if (s.dataset.section) acc.push([k + 1, s.dataset.section]);
+  return acc;
+}, []);
 
 let i = Math.min(Math.max((parseInt(location.hash.slice(1),10)||1)-1,0), slides.length-1);
 let overview = false;
@@ -376,7 +379,9 @@ function show(n, push=true) {
   slides.forEach((s,k) => s.classList.toggle("active", k===i));
   bar.style.width = ((i+1)/slides.length*100) + "%";
   cur.textContent = i+1;
-  secEl.textContent = SECTIONS.filter(([at]) => at <= i+1).pop()[1];
+  // textContent (not innerHTML) — section labels are plain text, never markup.
+  const sec = SECTIONS.filter(([at]) => at <= i+1).pop();
+  secEl.textContent = sec ? sec[1] : "";
   if (push) history.replaceState(null,"","#"+(i+1));
 }
 

--- a/agents/skills/slides/template.html
+++ b/agents/skills/slides/template.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- EDIT: deck title (browser tab) -->
+<title>Talk Title — Subtitle</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- THEME: fonts. Swap families here, then update --mono / --serif below. -->
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,600;0,800;1,400&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+<style>
+/* ════════════════════════════════════════════════════════════════
+   THEME — the swappable aesthetic. Change these to re-skin the deck.
+   Defaults are a terminal/TUI look (dark, teal accent, mono + serif).
+   ════════════════════════════════════════════════════════════════ */
+:root {
+  --bg: #07090f;          /* page background */
+  --bg-raise: #0c1018;    /* raised surfaces (status bar, window frames) */
+  --ink: #e8edf2;         /* primary text */
+  --dim: #5c6878;         /* secondary text */
+  --faint: #2a3240;       /* borders, rules */
+  --teal: #19c2bd;        /* ACCENT — emphasis, keys, progress */
+  --teal-dark: #0c615e;   /* accent, muted (divider numbers) */
+  --amber: #e8b04b;       /* warm highlight (branch label) */
+  --red: #e0556a;         /* warning / negative (.x) */
+  --green: #5dd39e;       /* positive / ok (.ok) */
+  --mono: "JetBrains Mono", ui-monospace, monospace;  /* body font */
+  --serif: "Instrument Serif", Georgia, serif;        /* display font (headings) */
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body { height: 100%; overflow: hidden; background: var(--bg); }
+body {
+  font-family: var(--mono);
+  color: var(--ink);
+  cursor: default;
+}
+
+/* ── atmosphere ─────────────────────────────────────────── */
+body::before {            /* scanlines */
+  content: ""; position: fixed; inset: 0; z-index: 40; pointer-events: none;
+  background: repeating-linear-gradient(0deg, rgba(255,255,255,.018) 0 1px, transparent 1px 3px);
+}
+body::after {             /* vignette + accent glow */
+  content: ""; position: fixed; inset: 0; z-index: 39; pointer-events: none;
+  background:
+    radial-gradient(ellipse 120% 90% at 50% 110%, rgba(25,194,189,.07), transparent 55%),
+    radial-gradient(ellipse 140% 120% at 50% 50%, transparent 60%, rgba(0,0,0,.5));
+}
+.grain {
+  position: fixed; inset: -50%; z-index: 41; pointer-events: none; opacity: .05;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='180' height='180'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='180' height='180' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grain 7s steps(8) infinite;
+}
+@keyframes grain {
+  0%,100% { transform: translate(0,0) } 25% { transform: translate(-2%,3%) }
+  50% { transform: translate(3%,-2%) } 75% { transform: translate(-3%,-3%) }
+}
+
+/* ── frame chrome ───────────────────────────────────────── */
+.frame {
+  position: fixed; inset: 14px; z-index: 30; pointer-events: none;
+  border: 1px solid var(--faint); border-radius: 6px;
+}
+.frame .tab {
+  position: absolute; top: -1px; left: 24px; transform: translateY(-50%);
+  background: var(--bg); padding: 0 12px;
+  font-size: 11px; letter-spacing: .12em; color: var(--dim);
+}
+.frame .tab b { color: var(--teal); font-weight: 600; }
+
+.statusbar {
+  position: fixed; left: 14px; right: 14px; bottom: 14px; z-index: 31;
+  display: flex; align-items: center; gap: 0;
+  height: 30px; border: 1px solid var(--faint); border-radius: 0 0 6px 6px;
+  border-top: 1px solid var(--faint);
+  background: var(--bg-raise);
+  font-size: 11.5px; user-select: none;
+}
+.statusbar .cell { padding: 0 14px; display: flex; align-items: center; gap: 7px; height: 100%; }
+.statusbar .sep { width: 1px; height: 100%; background: var(--faint); }
+.statusbar .mode { background: var(--teal); color: #03211f; font-weight: 800; letter-spacing: .1em; border-radius: 0 0 0 5px; }
+.statusbar .branch { color: var(--amber); }
+.statusbar .dim { color: var(--dim); }
+.statusbar .keys { margin-left: auto; color: var(--dim); border-radius: 0 0 5px 0; }
+.statusbar .keys b { color: var(--ink); font-weight: 600; }
+.statusbar .count b { color: var(--teal); font-weight: 800; }
+
+.progress {
+  position: fixed; left: 14px; right: 14px; top: 14px; height: 2px; z-index: 32;
+  background: transparent;
+}
+.progress i {
+  display: block; height: 100%; background: var(--teal);
+  width: 0; transition: width .35s cubic-bezier(.6,0,.2,1);
+  box-shadow: 0 0 12px rgba(25,194,189,.8);
+}
+
+/* ── slides ─────────────────────────────────────────────── */
+.deck { position: fixed; inset: 0; }
+.slide {
+  position: absolute; inset: 0;
+  display: flex; flex-direction: column; justify-content: center;
+  padding: 7vh 9vw;
+  opacity: 0; visibility: hidden;
+  transform: translateY(14px);
+  transition: opacity .38s ease, transform .38s cubic-bezier(.5,0,.15,1), visibility 0s .38s;
+}
+.slide.active {
+  opacity: 1; visibility: visible; transform: none;
+  transition: opacity .42s ease .05s, transform .42s cubic-bezier(.2,.7,.2,1) .05s;
+}
+.slide > * { opacity: 0; transform: translateY(12px); }
+.slide.active > * { animation: rise .55s cubic-bezier(.2,.7,.2,1) forwards; }
+.slide.active > *:nth-child(1) { animation-delay: .08s }
+.slide.active > *:nth-child(2) { animation-delay: .18s }
+.slide.active > *:nth-child(3) { animation-delay: .28s }
+.slide.active > *:nth-child(4) { animation-delay: .38s }
+@keyframes rise { to { opacity: 1; transform: none } }
+
+.crumb {
+  font-size: 12px; letter-spacing: .18em; text-transform: uppercase;
+  color: var(--dim); margin-bottom: 4.5vh;
+}
+.crumb::before { content: "❯ "; color: var(--teal); }
+
+/* big statement (one bold line) */
+.slide.big h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(2.6rem, 6.2vw, 5.4rem);
+  line-height: 1.08; letter-spacing: -.01em;
+  max-width: 22ch;
+}
+.slide.big h1 em { font-style: italic; color: var(--teal); }
+.slide.big h1 .cursor {
+  display: inline-block; width: .5em; height: .9em;
+  background: var(--teal); margin-left: .12em; vertical-align: baseline;
+  animation: blink 1.05s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0 } }
+
+/* section divider */
+.slide.divider { align-items: flex-start; }
+.slide.divider .num {
+  font-size: clamp(5rem, 14vw, 11rem); font-weight: 800; line-height: 1;
+  color: transparent; -webkit-text-stroke: 1.5px var(--teal-dark);
+  letter-spacing: -.04em;
+}
+.slide.divider h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(2.8rem, 6.5vw, 5.6rem); line-height: 1.05; margin-top: 1.5vh;
+}
+.slide.divider .rule { width: 16vw; height: 1px; background: var(--teal); margin-top: 4vh; box-shadow: 0 0 14px rgba(25,194,189,.7); }
+
+/* list slides */
+.slide.list h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(2.2rem, 4.6vw, 3.9rem); line-height: 1.1; margin-bottom: 5.5vh;
+  max-width: 26ch;
+}
+.slide.list ul { list-style: none; max-width: 62ch; }
+.slide.list li {
+  font-size: clamp(1rem, 1.7vw, 1.35rem); font-weight: 300;
+  line-height: 1.5; padding: 1.3vh 0 1.3vh 2.2em; position: relative;
+  border-top: 1px dashed var(--faint);
+}
+.slide.list li:first-child { border-top: none; }
+.slide.list li::before {
+  content: "▸"; position: absolute; left: .3em; color: var(--teal);
+}
+.slide.list li b { font-weight: 600; color: var(--teal); }
+.slide.list li .x { color: var(--red); }
+.slide.list li .ok { color: var(--green); }
+
+/* title slide */
+.slide.title { align-items: flex-start; }
+.slide.title .boot {
+  font-size: 12.5px; color: var(--dim); line-height: 1.9; margin-bottom: 5vh;
+}
+.slide.title .boot .ok { color: var(--green); }
+.slide.title h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(3.4rem, 8.6vw, 7.6rem); line-height: .98; letter-spacing: -.015em;
+}
+.slide.title h1 em { font-style: italic; color: var(--teal); }
+.slide.title .sub {
+  margin-top: 4.5vh; font-size: clamp(.8rem, 1.25vw, 1rem);
+  letter-spacing: .22em; text-transform: uppercase; color: var(--dim);
+}
+.slide.title .sub b { color: var(--amber); font-weight: 400; }
+
+/* image slides */
+.slide.shot h1 {
+  font-family: var(--serif); font-weight: 400;
+  font-size: clamp(1.9rem, 3.6vw, 3rem); margin-bottom: 3.5vh;
+}
+.slide.shot .win {
+  border: 1px solid var(--faint); border-radius: 8px; overflow: hidden;
+  background: var(--bg-raise);
+  box-shadow: 0 30px 80px rgba(0,0,0,.6), 0 0 0 1px rgba(25,194,189,.08), 0 0 60px rgba(25,194,189,.06);
+  max-width: min(82vw, 150vh);
+}
+.slide.shot .win .bar {
+  display: flex; gap: 6px; padding: 9px 12px; border-bottom: 1px solid var(--faint);
+}
+.slide.shot .win .bar i { width: 10px; height: 10px; border-radius: 50%; background: var(--faint); }
+.slide.shot .win .bar i:nth-child(1) { background: var(--red); }
+.slide.shot .win .bar i:nth-child(2) { background: var(--amber); }
+.slide.shot .win .bar i:nth-child(3) { background: var(--green); }
+.slide.shot .win img { display: block; width: 100%; height: auto; }
+
+/* closing question */
+.slide.question { align-items: center; text-align: center; }
+.slide.question h1 {
+  font-family: var(--serif); font-style: italic; font-weight: 400;
+  font-size: clamp(2.2rem, 4.8vw, 4.2rem); line-height: 1.25; max-width: 24ch;
+}
+.slide.question h1 .hl { color: var(--teal); }
+
+/* ── overview mode ──────────────────────────────────────── */
+.deck.overview .slide {
+  opacity: 1; visibility: visible; transform: none; transition: none;
+  position: static; padding: 12px; height: auto; justify-content: flex-start;
+  border: 1px solid var(--faint); border-radius: 4px; overflow: hidden;
+  font-size: 4px; min-height: 72px; cursor: pointer;
+}
+.deck.overview .slide > * { animation: none !important; opacity: 1; transform: none; }
+.deck.overview {
+  display: grid; grid-template-columns: repeat(8, 1fr); gap: 10px;
+  padding: 48px 24px; overflow-y: auto; align-content: start;
+}
+.deck.overview .slide h1 { font-size: 9px !important; line-height: 1.2; margin: 0 0 4px; max-width: none; }
+.deck.overview .slide li { font-size: 6px; padding: 2px 0 2px 10px; }
+.deck.overview .slide .crumb { font-size: 5px; margin-bottom: 4px; }
+.deck.overview .slide .num { font-size: 18px; -webkit-text-stroke: .5px var(--teal-dark); }
+.deck.overview .slide .rule, .deck.overview .slide .boot { display: none; }
+.deck.overview .slide .sub { font-size: 5px; margin-top: 4px; letter-spacing: .1em; }
+.deck.overview .slide.cursor-on { outline: 2px solid var(--teal); outline-offset: 1px; }
+.deck.overview .slide .win { max-width: 100%; }
+
+/* help overlay */
+.help {
+  position: fixed; inset: 0; z-index: 50; display: none;
+  align-items: center; justify-content: center;
+  background: rgba(4,6,10,.82); backdrop-filter: blur(6px);
+}
+.help.show { display: flex; }
+.help .panel {
+  border: 1px solid var(--faint); border-radius: 8px; background: var(--bg-raise);
+  padding: 28px 36px; font-size: 13px; line-height: 2.2; min-width: 320px;
+}
+.help .panel h2 { font-size: 12px; letter-spacing: .2em; color: var(--teal); margin-bottom: 12px; font-weight: 600; }
+.help kbd {
+  display: inline-block; min-width: 26px; text-align: center;
+  border: 1px solid var(--faint); border-bottom-width: 2px; border-radius: 4px;
+  padding: 1px 7px; margin-right: 12px; font-family: var(--mono); font-size: 11.5px;
+  color: var(--teal); background: var(--bg);
+}
+</style>
+</head>
+<body>
+<div class="grain"></div>
+<div class="progress"><i id="bar"></i></div>
+<!-- EDIT: window-tab label (left of frame, top). Keep it short. -->
+<div class="frame"><span class="tab">project — <b>talk-slug</b> — 80×24</span></div>
+
+<!-- ════════════════════════════════════════════════════════════════
+     SLIDES — one <section class="slide ..."> per slide.
+     Six archetypes (see references/archetypes.md): title, big, divider,
+     list, shot, question. Replace the examples below with your content.
+     ════════════════════════════════════════════════════════════════ -->
+<main class="deck" id="deck">
+
+  <!-- 1 · title -->
+  <section class="slide title">
+    <div class="boot">
+      <span class="ok">●</span> line one — a scene-setting status line<br>
+      <span class="ok">●</span> line two<br>
+      <span class="ok">●</span> line three
+    </div>
+    <h1>Talk Title<br>With an <em>emphasis</em></h1>
+    <div class="sub">Subtitle · <b>Event</b> · Month Year</div>
+  </section>
+
+  <!-- 2 · big — one bold statement, optional blinking cursor -->
+  <section class="slide big">
+    <div class="crumb">opening</div>
+    <h1>A single bold statement with one <em>emphasized</em> phrase.<span class="cursor"></span></h1>
+  </section>
+
+  <!-- 3 · divider — section opener. KEEP num in sync with SECTIONS below. -->
+  <section class="slide divider">
+    <div class="num">01</div>
+    <h1>First section</h1>
+    <div class="rule"></div>
+  </section>
+
+  <!-- 4 · list — up to 5 bullets. <b>=accent key, .x=warning, .ok=positive -->
+  <section class="slide list">
+    <h1>A list slide title</h1>
+    <ul>
+      <li><b>Accent key</b> — supporting detail</li>
+      <li>A point with a <span class="x">negative</span> callout</li>
+      <li>A point with a <span class="ok">positive</span> callout</li>
+    </ul>
+  </section>
+
+  <!-- 5 · shot — screenshot in a macOS-style window frame -->
+  <section class="slide shot">
+    <h1>A screenshot slide</h1>
+    <div class="win">
+      <div class="bar"><i></i><i></i><i></i></div>
+      <img src="screenshot.png" alt="Describe the screenshot for accessibility">
+    </div>
+  </section>
+
+  <!-- 6 · question — centered italic close -->
+  <section class="slide question">
+    <h1>A closing rhetorical question with a <span class="hl">highlight</span>?</h1>
+  </section>
+
+</main>
+
+<div class="statusbar">
+  <span class="cell mode" id="mode">PRESENT</span>
+  <!-- EDIT: branch/context label -->
+  <span class="cell branch">⎇ talk/slug</span>
+  <span class="sep"></span>
+  <span class="cell dim" id="section">opening</span>
+  <span class="sep"></span>
+  <!-- id="total" is overwritten at runtime from slides.length — static value is a placeholder -->
+  <span class="cell count">slide <b id="cur">1</b><span class="dim">/</span><b id="total">6</b></span>
+  <span class="cell keys keys-right">​<b>←→</b> navigate&nbsp;&nbsp;<b>o</b> overview&nbsp;&nbsp;<b>?</b> help</span>
+</div>
+
+<div class="help" id="help">
+  <div class="panel">
+    <h2>KEYBINDINGS</h2>
+    <div><kbd>→</kbd><kbd>space</kbd><kbd>j</kbd> next slide</div>
+    <div><kbd>←</kbd><kbd>k</kbd> previous slide</div>
+    <div><kbd>g</kbd><kbd>0</kbd> first slide</div>
+    <div><kbd>G</kbd> last slide</div>
+    <div><kbd>o</kbd> overview grid</div>
+    <div><kbd>?</kbd> toggle this help</div>
+  </div>
+</div>
+
+<script>
+const deck   = document.getElementById("deck");
+const slides = [...document.querySelectorAll(".slide")];
+const bar    = document.getElementById("bar");
+const cur    = document.getElementById("cur");
+const total  = document.getElementById("total");
+const mode   = document.getElementById("mode");
+const secEl  = document.getElementById("section");
+const help   = document.getElementById("help");
+
+/* ════════════════════════════════════════════════════════════════
+   SECTIONS — maps each section's FIRST slide number (1-indexed) to the
+   status-bar label shown for that range.  CRITICAL: when you add or
+   remove a slide, every later index shifts by ±1 — re-derive these
+   numbers or the labels (and divider 01/02/… numbers) silently desync.
+   ════════════════════════════════════════════════════════════════ */
+const SECTIONS = [
+  [1,"opening"],
+  [3,"01 · first section"],
+  [6,"close"]
+];
+
+let i = Math.min(Math.max((parseInt(location.hash.slice(1),10)||1)-1,0), slides.length-1);
+let overview = false;
+total.textContent = slides.length;
+
+function show(n, push=true) {
+  i = Math.min(Math.max(n,0), slides.length-1);
+  slides.forEach((s,k) => s.classList.toggle("active", k===i));
+  bar.style.width = ((i+1)/slides.length*100) + "%";
+  cur.textContent = i+1;
+  secEl.textContent = SECTIONS.filter(([at]) => at <= i+1).pop()[1];
+  if (push) history.replaceState(null,"","#"+(i+1));
+}
+
+function setOverview(on) {
+  overview = on;
+  deck.classList.toggle("overview", on);
+  mode.textContent = on ? "OVERVIEW" : "PRESENT";
+  if (on) {
+    slides.forEach((s,k) => s.classList.toggle("cursor-on", k===i));
+    slides[i].scrollIntoView({block:"center"});
+  } else {
+    slides.forEach(s => s.classList.remove("cursor-on"));
+    show(i,false);
+  }
+}
+
+slides.forEach((s,k) => s.addEventListener("click", () => { if (overview) { setOverview(false); show(k); } }));
+
+addEventListener("keydown", e => {
+  if (e.key === "?") { help.classList.toggle("show"); return; }
+  if (help.classList.contains("show")) { help.classList.remove("show"); return; }
+  if (e.key === "o") { setOverview(!overview); return; }
+  if (overview) {
+    let d = {ArrowRight:1, ArrowLeft:-1, j:1, k:-1, ArrowDown:8, ArrowUp:-8}[e.key];
+    if (d !== undefined) {
+      i = Math.min(Math.max(i+d,0), slides.length-1);
+      slides.forEach((s,k) => s.classList.toggle("cursor-on", k===i));
+      slides[i].scrollIntoView({block:"nearest"});
+      e.preventDefault();
+    }
+    if (e.key === "Enter") setOverview(false), show(i);
+    return;
+  }
+  switch (e.key) {
+    case "ArrowRight": case " ": case "j": case "PageDown": show(i+1); e.preventDefault(); break;
+    case "ArrowLeft":  case "k": case "PageUp":             show(i-1); e.preventDefault(); break;
+    case "Home": case "g": case "0": show(0); break;
+    case "End":  case "G":           show(slides.length-1); break;
+  }
+});
+
+/* tap / click to advance (mobile-friendly): left quarter = back, rest = forward */
+deck.addEventListener("click", e => {
+  if (overview) return;                       // overview clicks select a slide
+  if (help.classList.contains("show")) { help.classList.remove("show"); return; }
+  if (e.clientX < innerWidth * 0.25) show(i-1); else show(i+1);
+});
+
+/* swipe navigation */
+let tx = null, ty = null;
+addEventListener("touchstart", e => { tx = e.touches[0].clientX; ty = e.touches[0].clientY; }, {passive: true});
+addEventListener("touchend", e => {
+  if (tx === null || overview) return;
+  const dx = e.changedTouches[0].clientX - tx, dy = e.changedTouches[0].clientY - ty;
+  if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) show(dx < 0 ? i+1 : i-1);
+  tx = ty = null;
+}, {passive: true});
+
+addEventListener("hashchange", () => show((parseInt(location.hash.slice(1),10)||1)-1, false));
+show(i, false);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Add a `slides` skill that generates polished, single-file HTML presentation
decks from talking points or a source doc — a self-contained alternative to
Google Slides that opens in any browser and renders as a shareable artifact.

- template.html: terminal/TUI baseline with a swappable theme :root block, six
  slide archetypes (title, big, divider, list, shot, question), and a full
  navigation model (keyboard, overview grid, help, hash sync, progress bar,
  mobile tap + swipe). Section labels derive from data-section attributes at
  runtime, so adding/removing slides never desyncs the status bar.
- SKILL.md + references (archetypes, content conventions, theming): the
  doc-to-deck workflow, including QA and optional artifact publishing.
- scripts/inline-images.py: base64-inline images for offline/artifact use, with
  a path-traversal guard and img-scoped rewriting.
- Registered in the AGENTS.md routing table and README (skill count 66 -> 67).

Co-Authored-By: Claude <noreply@anthropic.com>