### PR TITLE
Rename argus-complete skill to complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dots docker stop-all     # Stop all Docker containers
 
 ## Agent Skills
 
-Dots includes 67 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
+Dots includes 68 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
 
 | Skill | Description |
 |-------|-------------|
@@ -120,6 +120,7 @@ Dots includes 67 reusable slash-command skills for AI coding agents, following t
 | `/loop` | Run a prompt on a recurring interval for polling, monitoring, and babysitting |
 | `/skill-usage` | Show skill usage statistics, charts, and suggestions for pruning unused skills |
 | `/wrapup` | End-of-session checklist that detects loose ends and routes to follow-up skills |
+| `/complete` | Mark the current Argus task's workflow status as complete via the `argus` MCP tool |
 | `/archive` | Archive the current Argus task at session end via the `argus` MCP tool |
 
 Skills use YAML frontmatter for metadata and dynamic context injection via shell commands. Some skills delegate to standalone bash scripts in `agents/skills/<name>/scripts/`. See `/write-skill` for the full authoring guide.
@@ -190,7 +191,7 @@ Run `dots install agents` to symlink them to `~/.claude/agents/`.
 ├── pi/                        # pi.dev coding agent config (models.json only)
 │
 ├── agents/                    # Agent configuration
-│   ├── skills/                # 67 reusable skills (SKILL.md per skill)
+│   ├── skills/                # 68 reusable skills (SKILL.md per skill)
 │   └── custom/                # 3 custom agent types (.md per agent)
 │       └── tests/             # Skill test suite
 │

--- a/agents/skills/complete/SKILL.md
+++ b/agents/skills/complete/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: argus-complete
+name: complete
 description: Mark the current Argus task as complete. Use when the work for the current worktree is done and the user wants the task to transition to the "complete" status.
 allowed-tools: mcp__argus__task_complete
 ---
@@ -8,7 +8,7 @@ allowed-tools: mcp__argus__task_complete
 
 Mark the Argus task owning the current worktree as `complete`. This sets the task's status to `complete` and stamps `EndedAt`. It does **not** stop a running agent session — if an agent is still attached, the user should stop it separately first.
 
-This skill is **not** the same as `/archive`. `/archive` moves the task into the Archive section (a visibility flag, independent of status). `/argus-complete` transitions the workflow status to `complete`. Use `/argus-complete` when the work is finished; use `/archive` (separately, optionally) if you also want it removed from the active task list.
+This skill is **not** the same as `/archive`. `/archive` moves the task into the Archive section (a visibility flag, independent of status). `/complete` transitions the workflow status to `complete`. Use `/complete` when the work is finished; use `/archive` (separately, optionally) if you also want it removed from the active task list.
 
 ## Context
 


### PR DESCRIPTION
Renames the `argus-complete` skill to `complete` so it is invoked as `/complete`. Updates the `name` frontmatter to match the new directory and the in-body slash-command references. Adds the previously-missing `/complete` row to the README skill table and corrects the skill count to 68.

Co-Authored-By: Claude <noreply@anthropic.com>