### PR TITLE
Add markdown-preview skill

### DIFF
--- a/.github/skill-tests/test_markdown_preview.sh
+++ b/.github/skill-tests/test_markdown_preview.sh
@@ -8,6 +8,22 @@ _source_render() {
   eval "$(sed 's/^main "\$@"//' "$RENDER")"
 }
 
+# Build a temp dir with stub `gh`/`jq` on PATH so the full pipeline runs
+# offline. Stub gh ignores its input and emits a fixed body; stub jq is a
+# no-op that satisfies the dependency check. Echoes the dir; PATH must be
+# prefixed with "$dir/bin" by the caller. Harness cleans the dir up on exit.
+_mdp_stub_dir() {
+  local dir
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/mdp-XXXXXX")
+  _TMPDIRS+=("$dir")
+  mkdir -p "$dir/bin"
+  printf '#!/usr/bin/env bash\ncat >/dev/null\nprintf "%%s" "<p>STUB BODY</p>"\n' > "$dir/bin/gh"
+  printf '#!/usr/bin/env bash\nprintf "%%s" "{}"\n' > "$dir/bin/jq"
+  chmod +x "$dir/bin/gh" "$dir/bin/jq"
+  printf '# Hi\n' > "$dir/doc.md"
+  echo "$dir"
+}
+
 test_preview_path_basic() {
   _source_render
   assert_eq "$(preview_path "docs/README.md")" "docs/README-preview.html" \
@@ -66,6 +82,44 @@ test_out_rejects_flag_as_value() {
   capture bash "$RENDER" somefile.md --out --no-open
   assert_eq "$_CAPTURED_EXIT" "1" "--out followed by a flag exits 1"
   assert_contains "$_CAPTURED" "requires a path" "does not consume --no-open as the path"
+}
+
+test_wrap_html_escapes_ampersand_first() {
+  _source_render
+  local doc
+  doc="$(wrap_html "A & B" "<p>x</p>")"
+  assert_contains "$doc" "<title>A &amp; B</title>" "bare ampersand becomes &amp;"
+  assert_not_contains "$doc" "&amp;amp;" "no double-escaping of the ampersand"
+}
+
+test_wrap_stdin_requires_title() {
+  capture bash "$RENDER" --wrap-stdin
+  assert_eq "$_CAPTURED_EXIT" "1" "--wrap-stdin with no title exits 1"
+  assert_contains "$_CAPTURED" "requires a title" "reports missing title"
+}
+
+test_render_print_path_only_emits_path() {
+  local dir out
+  dir=$(_mdp_stub_dir)
+  out=$(PATH="$dir/bin:$PATH" bash "$RENDER" "$dir/doc.md" --no-open --print-path)
+  assert_eq "$out" "$dir/doc-preview.html" "--print-path emits only the path"
+  assert_not_contains "$out" "Wrote preview" "no friendly prefix under --print-path"
+  assert_contains "$(cat "$dir/doc-preview.html")" "STUB BODY" "preview embeds rendered body"
+}
+
+test_render_default_prints_friendly_message() {
+  local dir out
+  dir=$(_mdp_stub_dir)
+  out=$(PATH="$dir/bin:$PATH" bash "$RENDER" "$dir/doc.md" --no-open)
+  assert_contains "$out" "Wrote preview:" "default run prints friendly message"
+  assert_contains "$out" "doc-preview.html" "message includes the preview path"
+}
+
+test_render_out_writes_custom_path() {
+  local dir
+  dir=$(_mdp_stub_dir)
+  PATH="$dir/bin:$PATH" bash "$RENDER" "$dir/doc.md" --out "$dir/custom.html" --no-open >/dev/null
+  assert_contains "$(cat "$dir/custom.html")" "STUB BODY" "--out writes to the custom path"
 }
 
 test_wrap_html_light_dark() {

--- a/.github/skill-tests/test_markdown_preview.sh
+++ b/.github/skill-tests/test_markdown_preview.sh
@@ -176,6 +176,28 @@ test_nonexistent_file() {
 test_unknown_flag() {
   capture bash "$RENDER" --bogus
   assert_eq "$_CAPTURED_EXIT" "1" "exits 1 on unknown flag"
+  assert_contains "$_CAPTURED" "Unknown flag" "reports the unknown flag"
+}
+
+test_wrap_html_escapes_double_quote() {
+  _source_render
+  local doc
+  doc="$(wrap_html 'a"b' "<p>x</p>")"
+  assert_contains "$doc" "<title>a&quot;b</title>" "double quote in title is escaped"
+}
+
+# Exercises the real jq encoding (the integration tests stub jq out, so this
+# is the only check that the API request payload has the right shape).
+test_build_payload_shape() {
+  command -v jq >/dev/null 2>&1 || return 0
+  _source_render
+  local dir payload
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/mdp-XXXXXX")
+  _TMPDIRS+=("$dir")
+  printf '# Heading\n' > "$dir/d.md"
+  payload=$(build_payload "$dir/d.md")
+  assert_contains "$payload" '"mode": "gfm"' "payload requests gfm mode"
+  assert_contains "$payload" "Heading" "payload carries the markdown text"
 }
 
 run_tests

--- a/.github/skill-tests/test_markdown_preview.sh
+++ b/.github/skill-tests/test_markdown_preview.sh
@@ -122,6 +122,28 @@ test_render_out_writes_custom_path() {
   assert_contains "$(cat "$dir/custom.html")" "STUB BODY" "--out writes to the custom path"
 }
 
+test_render_open_failure_does_not_abort() {
+  local dir code=0
+  dir=$(_mdp_stub_dir)
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$dir/bin/open"
+  chmod +x "$dir/bin/open"
+  PATH="$dir/bin:$PATH" bash "$RENDER" "$dir/doc.md" >/dev/null 2>&1 || code=$?
+  assert_eq "$code" "0" "a failed browser opener does not abort the script"
+  assert_contains "$(cat "$dir/doc-preview.html")" "STUB BODY" "preview is written even when open fails"
+}
+
+test_out_rejects_empty_value() {
+  capture bash "$RENDER" somefile.md --out ""
+  assert_eq "$_CAPTURED_EXIT" "1" "--out with an empty value exits 1"
+  assert_contains "$_CAPTURED" "requires a path" "reports empty --out value"
+}
+
+test_wrap_stdin_rejects_empty_title() {
+  capture bash "$RENDER" --wrap-stdin ""
+  assert_eq "$_CAPTURED_EXIT" "1" "--wrap-stdin with an empty title exits 1"
+  assert_contains "$_CAPTURED" "requires a title" "reports empty --wrap-stdin title"
+}
+
 test_wrap_html_light_dark() {
   _source_render
   local doc

--- a/.github/skill-tests/test_markdown_preview.sh
+++ b/.github/skill-tests/test_markdown_preview.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+source "$(dirname "$0")/harness.sh"
+
+RENDER="$SCRIPTS_DIR/markdown-preview/scripts/render.sh"
+
+# Source the script to access functions without running main.
+_source_render() {
+  eval "$(sed 's/^main "\$@"//' "$RENDER")"
+}
+
+test_preview_path_basic() {
+  _source_render
+  assert_eq "$(preview_path "docs/README.md")" "docs/README-preview.html" \
+    "preview path next to source, .md stripped"
+}
+
+test_preview_path_no_dir() {
+  _source_render
+  assert_eq "$(preview_path "NOTES.md")" "./NOTES-preview.html" \
+    "bare filename gets ./ dir from dirname"
+}
+
+test_preview_path_markdown_ext() {
+  _source_render
+  assert_eq "$(preview_path "a/b/guide.markdown")" "a/b/guide-preview.html" \
+    "longest-ext strip handles .markdown"
+}
+
+test_wrap_html_structure() {
+  _source_render
+  local doc
+  doc="$(wrap_html "My Title" "<h1>Hello</h1>")"
+  assert_contains "$doc" "<!doctype html>" "emits doctype"
+  assert_contains "$doc" "<title>My Title</title>" "title is interpolated"
+  assert_contains "$doc" "<h1>Hello</h1>" "body is embedded"
+  assert_contains "$doc" "markdown-body" "uses markdown-body article class"
+}
+
+test_wrap_html_light_dark() {
+  _source_render
+  local doc
+  doc="$(wrap_html "T" "<p>x</p>")"
+  assert_contains "$doc" "prefers-color-scheme: dark" "has dark mode block"
+  assert_contains "$doc" "color-scheme: light dark" "declares light+dark"
+  assert_contains "$doc" "max-width: 1012px" "GitHub content width"
+}
+
+test_wrap_stdin_hook() {
+  _source_render
+  local doc
+  doc="$(echo "<p>piped body</p>" | bash "$RENDER" --wrap-stdin "Piped")"
+  assert_contains "$doc" "<title>Piped</title>" "stdin hook sets title"
+  assert_contains "$doc" "<p>piped body</p>" "stdin hook embeds piped body"
+}
+
+test_missing_file_arg() {
+  capture bash "$RENDER"
+  assert_eq "$_CAPTURED_EXIT" "1" "exits 1 with no file"
+  assert_contains "$_CAPTURED" "no markdown file" "reports missing file arg"
+}
+
+test_nonexistent_file() {
+  capture bash "$RENDER" "/no/such/file-xyz.md"
+  assert_eq "$_CAPTURED_EXIT" "1" "exits 1 for missing file"
+  assert_contains "$_CAPTURED" "file not found" "reports file not found"
+}
+
+test_unknown_flag() {
+  capture bash "$RENDER" --bogus
+  assert_eq "$_CAPTURED_EXIT" "1" "exits 1 on unknown flag"
+}
+
+run_tests

--- a/.github/skill-tests/test_markdown_preview.sh
+++ b/.github/skill-tests/test_markdown_preview.sh
@@ -36,6 +36,38 @@ test_wrap_html_structure() {
   assert_contains "$doc" "markdown-body" "uses markdown-body article class"
 }
 
+test_preview_path_dotfile() {
+  _source_render
+  assert_eq "$(preview_path ".hidden")" "./.hidden-preview.html" \
+    "dotfile keeps its name instead of stripping to empty"
+}
+
+test_preview_path_multidot() {
+  _source_render
+  assert_eq "$(preview_path "a.b.md")" "./a.b-preview.html" \
+    "only the last extension is stripped"
+}
+
+test_wrap_html_escapes_title() {
+  _source_render
+  local doc
+  doc="$(wrap_html "<script>x</script>" "<p>body</p>")"
+  assert_contains "$doc" "&lt;script&gt;x&lt;/script&gt;" "title markup is escaped"
+  assert_not_contains "$doc" "<title><script>" "raw script tag not in title"
+}
+
+test_out_requires_value() {
+  capture bash "$RENDER" somefile.md --out
+  assert_eq "$_CAPTURED_EXIT" "1" "--out with no value exits 1"
+  assert_contains "$_CAPTURED" "requires a path" "reports --out needs a path"
+}
+
+test_out_rejects_flag_as_value() {
+  capture bash "$RENDER" somefile.md --out --no-open
+  assert_eq "$_CAPTURED_EXIT" "1" "--out followed by a flag exits 1"
+  assert_contains "$_CAPTURED" "requires a path" "does not consume --no-open as the path"
+}
+
 test_wrap_html_light_dark() {
   _source_render
   local doc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,7 +182,7 @@ When the user's message matches a phrase below, read and follow the correspondin
 | "skill usage", "which skills do I use", "unused skills", "skill stats", "skill suggestions" | `agents/skills/skill-usage/SKILL.md` |
 | "dream", "KB hygiene", "knowledge base cleanup", "memory hygiene", "audit KB", "dream consolidation" | `agents/skills/dream/SKILL.md` |
 | "create slides", "build a presentation", "make a deck", "turn talking points into a talk", "HTML slideshow", "presentation deck" | `agents/skills/slides/SKILL.md` |
-| "preview markdown", "render markdown", "how does this README render on GitHub", "GitHub-flavored markdown preview", "check screenshots render", "markdown preview" | `agents/skills/markdown-preview/SKILL.md` |
+| "preview markdown", "render markdown", "how does this README render on GitHub", "GitHub-flavored markdown preview", "check that images render on GitHub", "markdown preview" | `agents/skills/markdown-preview/SKILL.md` |
 
 ## Public Repo Policy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,6 +182,7 @@ When the user's message matches a phrase below, read and follow the correspondin
 | "skill usage", "which skills do I use", "unused skills", "skill stats", "skill suggestions" | `agents/skills/skill-usage/SKILL.md` |
 | "dream", "KB hygiene", "knowledge base cleanup", "memory hygiene", "audit KB", "dream consolidation" | `agents/skills/dream/SKILL.md` |
 | "create slides", "build a presentation", "make a deck", "turn talking points into a talk", "HTML slideshow", "presentation deck" | `agents/skills/slides/SKILL.md` |
+| "preview markdown", "render markdown", "how does this README render on GitHub", "GitHub-flavored markdown preview", "check screenshots render", "markdown preview" | `agents/skills/markdown-preview/SKILL.md` |
 
 ## Public Repo Policy
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Dots includes 68 reusable slash-command skills for AI coding agents, following t
 | `/retro` | Structured retrospective or post-incident review |
 | `/logo` | Logo generation |
 | `/slides` | Build a self-contained HTML presentation deck from talking points or a doc, with keyboard, tap, and swipe navigation |
+| `/markdown-preview` | Render a Markdown file to GitHub-flavored HTML via `gh api /markdown` and open a styled local preview (light + dark) |
 | `/improve` | Improve skills, capture context and knowledge |
 | `/rereview` | Re-review with fresh eyes, zero regressions |
 | `/rereview-loop` | Run `/rereview`, fix the findings, and loop until reviewers approve clean |

--- a/agents/skills/markdown-preview/SKILL.md
+++ b/agents/skills/markdown-preview/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: markdown-preview
+description: Render a Markdown file to GitHub-flavored HTML and open a styled local preview (light + dark) in the browser. Use when the user wants to preview markdown, see how a README renders on GitHub, check that relative screenshots or images display correctly, or get a GitHub-like local preview without installing grip or glow.
+allowed-tools: Bash(bash *), Bash(gh api *), Bash(rm *), Read, Edit
+---
+
+# Markdown Preview
+
+Render a Markdown file the way GitHub would (GFM: tables, task lists, fenced
+code) and open a self-contained, GitHub-styled HTML preview with light and dark
+support. Rendering goes through `gh api /markdown`, so no local renderer
+(grip/glow) is needed — only an authenticated `gh` CLI and `jq`.
+
+The preview is written ALONGSIDE the source file by default. This is
+deliberate: relative image paths (e.g. `screenshots/foo.png`) only resolve when
+the HTML lives in the same directory as the markdown.
+
+## When to stop and ask
+
+- If no markdown file path is given and none is obvious from context, ask the
+  user which file to preview. Do not guess.
+- If the file is not a markdown file (`.md` / `.markdown`), confirm before
+  rendering.
+
+## Privacy note
+
+`gh api /markdown` sends the file's contents to GitHub over the network. This
+is fine for public README / docs content. If the markdown contains anything
+sensitive, tell the user it will leave the machine and confirm before rendering.
+
+## Workflow
+
+### Step 1 — Resolve the file
+
+Identify the markdown file path from the argument (`$1`) or conversation
+context. Confirm it exists.
+
+### Step 2 — Render and open
+
+Run the render script. `<skill-dir>` is the directory containing this SKILL.md:
+
+```
+bash <skill-dir>/scripts/render.sh <file.md>
+```
+
+This renders via `gh api /markdown`, writes `<file>-preview.html` next to the
+source, and opens it in the default browser (macOS `open`, Linux `xdg-open`,
+Windows `start`).
+
+Useful flags:
+- `--no-open` — write the preview but do not launch a browser.
+- `--out <path>` — choose the output path. Use ONLY when the markdown has no
+  relative images; a path outside the source directory breaks relative `src`.
+
+If the script reports `gh` is not installed or `gh api /markdown` failed,
+relay the error: the user likely needs to install `gh` or run `gh auth status`.
+Do not retry more than once.
+
+### Step 3 — Cleanup
+
+The preview is a temporary artifact and should not be committed. After the user
+is done viewing:
+- Offer to remove it: `rm <file>-preview.html`.
+- If the file sits inside a git repository, optionally suggest adding
+  `*-preview.html` to `.gitignore` so regenerating it does not leave untracked
+  files (this was the original pain point this skill was built to avoid).
+
+To re-preview after editing the markdown, just rerun Step 2 — it overwrites the
+existing preview.

--- a/agents/skills/markdown-preview/SKILL.md
+++ b/agents/skills/markdown-preview/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: markdown-preview
 description: Render a Markdown file to GitHub-flavored HTML and open a styled local preview (light + dark) in the browser. Use when the user wants to preview markdown, see how a README renders on GitHub, check that relative screenshots or images display correctly, or get a GitHub-like local preview without installing grip or glow.
-allowed-tools: Bash(bash *), Bash(gh api *), Bash(rm *), Read, Edit
+allowed-tools: Bash(bash *), Bash(gh api *), Bash(rm *-preview.html), Read, Edit
 ---
 
 # Markdown Preview
@@ -49,18 +49,27 @@ Windows `start`).
 
 Useful flags:
 - `--no-open` — write the preview but do not launch a browser.
-- `--out <path>` — choose the output path. Use ONLY when the markdown has no
-  relative images; a path outside the source directory breaks relative `src`.
+- `--out <path>` — choose the output path (requires a value). Use ONLY when the
+  markdown has no relative images; a path outside the source directory breaks
+  relative `src`.
+- `--print-path` — print only the written preview path to stdout (instead of the
+  friendly "Wrote preview:" line). Use when chaining or capturing the path.
 
-If the script reports `gh` is not installed or `gh api /markdown` failed,
-relay the error: the user likely needs to install `gh` or run `gh auth status`.
-Do not retry more than once.
+The script prints the preview path it wrote. Note that path for the cleanup
+step — it is `<file>-preview.html` next to the source unless `--out` overrode it.
+
+If the script reports a missing dependency or a failed render, relay the error
+and do not retry more than once:
+- `gh` not installed → install the GitHub CLI, or fall back to `grip`/`glow`.
+- `gh api /markdown` failed → likely an auth issue; suggest `gh auth status`.
+- `jq` not installed → install `jq` (required to encode the request body).
 
 ### Step 3 — Cleanup
 
 The preview is a temporary artifact and should not be committed. After the user
 is done viewing:
-- Offer to remove it: `rm <file>-preview.html`.
+- Offer to remove it, using the exact preview path the script reported (the
+  default is `<file>-preview.html`; it differs when `--out` was used).
 - If the file sits inside a git repository, optionally suggest adding
   `*-preview.html` to `.gitignore` so regenerating it does not leave untracked
   files (this was the original pain point this skill was built to avoid).

--- a/agents/skills/markdown-preview/SKILL.md
+++ b/agents/skills/markdown-preview/SKILL.md
@@ -69,7 +69,9 @@ and do not retry more than once:
 The preview is a temporary artifact and should not be committed. After the user
 is done viewing:
 - Offer to remove it, using the exact preview path the script reported (the
-  default is `<file>-preview.html`; it differs when `--out` was used).
+  default is `<file>-preview.html`; it differs when `--out` was used). Auto-run
+  of `rm` is pre-approved only for the default `*-preview.html` name; removing a
+  custom `--out` path will prompt for confirmation, which is fine.
 - If the file sits inside a git repository, optionally suggest adding
   `*-preview.html` to `.gitignore` so regenerating it does not leave untracked
   files (this was the original pain point this skill was built to avoid).

--- a/agents/skills/markdown-preview/scripts/render.sh
+++ b/agents/skills/markdown-preview/scripts/render.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+#
+# render.sh — render a Markdown file to GitHub-flavored HTML and open a preview.
+#
+# Renders the markdown via `gh api /markdown` (mode: gfm — true GitHub
+# rendering of tables, task lists, etc.), wraps the result in a self-contained,
+# GitHub-styled HTML document (light + dark via prefers-color-scheme), writes
+# the preview ALONGSIDE the source file so relative image paths resolve, then
+# opens it in the default browser.
+#
+# Usage:
+#   render.sh <file.md> [--out <path>] [--no-open] [--print-path]
+#
+# Flags:
+#   --out <path>    Write the preview to <path> instead of <file>-preview.html.
+#                   Use only when the markdown has no relative assets — a path
+#                   outside the source directory will break relative image src.
+#   --no-open       Render and write the file but do not launch a browser.
+#   --print-path    Print only the written preview path to stdout.
+#   -h, --help      Show usage.
+#
+# Hidden test hook (no network, no gh — used by the bash tests):
+#   --wrap-stdin <title>   Read body HTML from stdin, emit the wrapped document
+#                          to stdout, and exit.
+#
+# Requires: gh (authenticated), jq. macOS `open`, Linux `xdg-open`, or
+# Windows `start` for the open step.
+
+set -euo pipefail
+
+usage() {
+  sed -n '3,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# Compute the default preview path: <dir>/<name>-preview.html next to source.
+preview_path() {
+  local md="$1" dir base name
+  dir="$(dirname "$md")"
+  base="$(basename "$md")"
+  name="${base%.*}"
+  echo "${dir}/${name}-preview.html"
+}
+
+# Emit a self-contained, GitHub-styled HTML document wrapping the body HTML.
+# wrap_html <title> <body-html>
+wrap_html() {
+  local title="$1" body="$2"
+  cat <<HTML
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+  :root { color-scheme: light dark; }
+  body {
+    margin: 0;
+    background: #ffffff;
+    color: #1f2328;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans",
+      Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+  }
+  .markdown-body {
+    box-sizing: border-box;
+    max-width: 1012px;
+    margin: 0 auto;
+    padding: 32px 16px 64px;
+  }
+  .markdown-body h1, .markdown-body h2 {
+    border-bottom: 1px solid #d1d9e0;
+    padding-bottom: .3em;
+  }
+  .markdown-body h1, .markdown-body h2, .markdown-body h3,
+  .markdown-body h4, .markdown-body h5, .markdown-body h6 {
+    margin-top: 24px;
+    margin-bottom: 16px;
+    font-weight: 600;
+    line-height: 1.25;
+  }
+  .markdown-body a { color: #0969da; text-decoration: none; }
+  .markdown-body a:hover { text-decoration: underline; }
+  .markdown-body img { max-width: 100%; box-sizing: content-box; }
+  .markdown-body code {
+    padding: .2em .4em;
+    margin: 0;
+    font-size: 85%;
+    background: rgba(129,139,152,0.12);
+    border-radius: 6px;
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+      "Liberation Mono", monospace;
+  }
+  .markdown-body pre {
+    padding: 16px;
+    overflow: auto;
+    font-size: 85%;
+    line-height: 1.45;
+    background: #f6f8fa;
+    border-radius: 6px;
+  }
+  .markdown-body pre code { padding: 0; background: transparent; border: 0; }
+  .markdown-body blockquote {
+    margin: 0;
+    padding: 0 1em;
+    color: #59636e;
+    border-left: .25em solid #d1d9e0;
+  }
+  .markdown-body table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: block;
+    width: max-content;
+    max-width: 100%;
+    overflow: auto;
+  }
+  .markdown-body table th, .markdown-body table td {
+    padding: 6px 13px;
+    border: 1px solid #d1d9e0;
+  }
+  .markdown-body table tr:nth-child(2n) { background: #f6f8fa; }
+  .markdown-body hr { height: .25em; background: #d1d9e0; border: 0; }
+  .markdown-body .task-list-item { list-style-type: none; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #0d1117; color: #e6edf3; }
+    .markdown-body h1, .markdown-body h2 { border-bottom-color: #3d444d; }
+    .markdown-body a { color: #4493f8; }
+    .markdown-body code { background: rgba(101,108,118,0.2); }
+    .markdown-body pre { background: #151b23; }
+    .markdown-body blockquote { color: #9198a1; border-left-color: #3d444d; }
+    .markdown-body table th, .markdown-body table td { border-color: #3d444d; }
+    .markdown-body table tr:nth-child(2n) { background: #151b23; }
+    .markdown-body hr { background: #3d444d; }
+  }
+</style>
+</head>
+<body>
+<article class="markdown-body">
+${body}
+</article>
+</body>
+</html>
+HTML
+}
+
+# Render the body HTML from a markdown file via the GitHub API.
+render_body() {
+  local md="$1"
+  jq -Rs '{text: ., mode: "gfm"}' "$md" | gh api --method POST /markdown --input -
+}
+
+# Open a file in the default browser, branching on platform.
+open_file() {
+  local f="$1"
+  if command -v open >/dev/null 2>&1; then
+    open "$f"
+  elif command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$f"
+  elif command -v start >/dev/null 2>&1; then
+    start "" "$f"
+  else
+    echo "No browser opener found (open/xdg-open/start). Preview at: $f" >&2
+  fi
+}
+
+main() {
+  local file="" out="" do_open=1 print_path=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --wrap-stdin) shift; wrap_html "${1:-Preview}" "$(cat)"; return 0 ;;
+      --out) shift; out="${1:-}" ;;
+      --no-open) do_open=0 ;;
+      --print-path) print_path=1 ;;
+      -h|--help) usage; return 0 ;;
+      -*) echo "Unknown flag: $1" >&2; usage >&2; return 1 ;;
+      *) file="$1" ;;
+    esac
+    shift
+  done
+
+  if [[ -z "$file" ]]; then
+    echo "Error: no markdown file given." >&2
+    usage >&2
+    return 1
+  fi
+  if [[ ! -f "$file" ]]; then
+    echo "Error: file not found: $file" >&2
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required but not installed." >&2
+    return 1
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh (GitHub CLI) is required but not installed." >&2
+    echo "Install it, or render with a local tool such as 'grip' or 'glow'." >&2
+    return 1
+  fi
+
+  [[ -z "$out" ]] && out="$(preview_path "$file")"
+
+  local body
+  if ! body="$(render_body "$file")"; then
+    echo "Error: 'gh api /markdown' failed. Check auth with: gh auth status" >&2
+    return 1
+  fi
+
+  wrap_html "$(basename "$file")" "$body" > "$out"
+
+  if [[ "$print_path" -eq 1 ]]; then
+    echo "$out"
+  else
+    echo "Wrote preview: $out"
+  fi
+
+  [[ "$do_open" -eq 1 ]] && open_file "$out"
+  return 0
+}
+
+main "$@"

--- a/agents/skills/markdown-preview/scripts/render.sh
+++ b/agents/skills/markdown-preview/scripts/render.sh
@@ -177,18 +177,21 @@ render_body() {
   jq -Rs '{text: ., mode: "gfm"}' "$md" | gh api --method POST /markdown --input -
 }
 
-# Open a file in the default browser, branching on platform.
+# Open a file in the default browser, branching on platform. Opening is
+# best-effort: the preview has already been written, so a failed or missing
+# opener (e.g. headless/CI) must not abort the script. Always returns 0.
 open_file() {
   local f="$1"
   if command -v open >/dev/null 2>&1; then
-    open "$f"
+    open "$f" || echo "Could not open $f automatically. Preview is at: $f" >&2
   elif command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$f"
+    xdg-open "$f" || echo "Could not open $f automatically. Preview is at: $f" >&2
   elif command -v start >/dev/null 2>&1; then
-    start "" "$f"
+    start "" "$f" || echo "Could not open $f automatically. Preview is at: $f" >&2
   else
     echo "No browser opener found (open/xdg-open/start). Preview at: $f" >&2
   fi
+  return 0
 }
 
 main() {
@@ -198,7 +201,7 @@ main() {
     case "$1" in
       --wrap-stdin)
         shift
-        if [[ $# -eq 0 || "${1:-}" == -* ]]; then
+        if [[ $# -eq 0 || -z "${1:-}" || "${1:-}" == -* ]]; then
           echo "Error: --wrap-stdin requires a title argument." >&2
           return 1
         fi
@@ -207,7 +210,7 @@ main() {
         ;;
       --out)
         shift
-        if [[ $# -eq 0 || "${1:-}" == -* ]]; then
+        if [[ $# -eq 0 || -z "${1:-}" || "${1:-}" == -* ]]; then
           echo "Error: --out requires a path argument." >&2
           return 1
         fi

--- a/agents/skills/markdown-preview/scripts/render.sh
+++ b/agents/skills/markdown-preview/scripts/render.sh
@@ -28,8 +28,26 @@
 
 set -euo pipefail
 
+# Print user-facing help. Kept as a static block (not scraped from the header
+# comment) so the developer-only --wrap-stdin hook is never shown to users.
 usage() {
-  sed -n '3,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  cat <<'USAGE'
+render.sh — render a Markdown file to GitHub-flavored HTML and open a preview.
+
+Usage:
+  render.sh <file.md> [--out <path>] [--no-open] [--print-path]
+
+Flags:
+  --out <path>    Write the preview to <path> instead of <file>-preview.html.
+                  Use only when the markdown has no relative assets — a path
+                  outside the source directory will break relative image src.
+  --no-open       Render and write the file but do not launch a browser.
+  --print-path    Print only the written preview path to stdout.
+  -h, --help      Show usage.
+
+Requires: gh (authenticated), jq. macOS `open`, Linux `xdg-open`, or
+Windows `start` for the open step.
+USAGE
 }
 
 # Compute the default preview path: <dir>/<name>-preview.html next to source.
@@ -178,7 +196,15 @@ main() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --wrap-stdin) shift; wrap_html "${1:-Preview}" "$(cat)"; return 0 ;;
+      --wrap-stdin)
+        shift
+        if [[ $# -eq 0 || "${1:-}" == -* ]]; then
+          echo "Error: --wrap-stdin requires a title argument." >&2
+          return 1
+        fi
+        wrap_html "$1" "$(cat)"
+        return 0
+        ;;
       --out)
         shift
         if [[ $# -eq 0 || "${1:-}" == -* ]]; then

--- a/agents/skills/markdown-preview/scripts/render.sh
+++ b/agents/skills/markdown-preview/scripts/render.sh
@@ -29,7 +29,7 @@
 set -euo pipefail
 
 usage() {
-  sed -n '3,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '3,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 # Compute the default preview path: <dir>/<name>-preview.html next to source.
@@ -38,6 +38,9 @@ preview_path() {
   dir="$(dirname "$md")"
   base="$(basename "$md")"
   name="${base%.*}"
+  # A dotfile with no other extension (e.g. ".hidden") strips to empty; keep
+  # the original name so the preview path is never "./-preview.html".
+  [[ -z "$name" ]] && name="$base"
   echo "${dir}/${name}-preview.html"
 }
 
@@ -45,6 +48,12 @@ preview_path() {
 # wrap_html <title> <body-html>
 wrap_html() {
   local title="$1" body="$2"
+  # Escape the title (derived from the filename) so an exotic name cannot
+  # inject markup into the <title> element. The body is GitHub-rendered HTML
+  # and is intentionally emitted as-is.
+  title="${title//&/&amp;}"
+  title="${title//</&lt;}"
+  title="${title//>/&gt;}"
   cat <<HTML
 <!doctype html>
 <html lang="en">
@@ -170,7 +179,14 @@ main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --wrap-stdin) shift; wrap_html "${1:-Preview}" "$(cat)"; return 0 ;;
-      --out) shift; out="${1:-}" ;;
+      --out)
+        shift
+        if [[ $# -eq 0 || "${1:-}" == -* ]]; then
+          echo "Error: --out requires a path argument." >&2
+          return 1
+        fi
+        out="$1"
+        ;;
       --no-open) do_open=0 ;;
       --print-path) print_path=1 ;;
       -h|--help) usage; return 0 ;;

--- a/agents/skills/markdown-preview/scripts/render.sh
+++ b/agents/skills/markdown-preview/scripts/render.sh
@@ -72,6 +72,7 @@ wrap_html() {
   title="${title//&/&amp;}"
   title="${title//</&lt;}"
   title="${title//>/&gt;}"
+  title="${title//\"/&quot;}"
   cat <<HTML
 <!doctype html>
 <html lang="en">
@@ -171,10 +172,17 @@ ${body}
 HTML
 }
 
+# Build the JSON request body for the GitHub markdown API: the file slurped
+# raw into `text`, rendered in GitHub-flavored mode. Kept separate from the
+# network call so the payload shape is unit-testable.
+build_payload() {
+  jq -Rs '{text: ., mode: "gfm"}' "$1"
+}
+
 # Render the body HTML from a markdown file via the GitHub API.
 render_body() {
   local md="$1"
-  jq -Rs '{text: ., mode: "gfm"}' "$md" | gh api --method POST /markdown --input -
+  build_payload "$md" | gh api --method POST /markdown --input -
 }
 
 # Open a file in the default browser, branching on platform. Opening is


### PR DESCRIPTION
Render a Markdown file to GitHub-flavored HTML via `gh api /markdown` (mode gfm), wrap it in a self-contained light/dark styled HTML doc written alongside the source so relative image paths resolve, then open it in the browser.

- agents/skills/markdown-preview/SKILL.md + scripts/render.sh (testable build_payload/wrap_html/preview_path; best-effort cross-platform open; validated flags --out/--no-open/--print-path)
- .github/skill-tests/test_markdown_preview.sh — 45 assertions (path mapping, title escaping, arg validation, stub-based integration, open-failure resilience, real-jq payload shape)
- AGENTS.md routing-table row for non-Claude agents; README skill-table entry

Reviewed via 4 rounds of /rereview (converged to unanimous APPROVE, 0 blocking/0 warning) plus a /review pass; all findings addressed.

Co-Authored-By: Claude <noreply@anthropic.com>