### PR TITLE
fix(tmux): move clear macro off C-k to C-/ so apps get Ctrl+K

### DIFF
--- a/home/tmux.conf
+++ b/home/tmux.conf
@@ -51,8 +51,9 @@ set -g prefix `
 bind ` send-prefix
 # bind prefix-R to reload tmux.conf
 bind R source-file ~/.tmux.conf \; refresh-client -S \; display-message "Reloading...";
-# clear window binding
-bind -n C-k send-keys C-l \; run-shell "sleep 0.3" \; clear-history
+# clear window binding (C-/ ; bind both encodings since terminals send C-/ or C-_)
+bind -n C-/ send-keys C-l \; run-shell "sleep 0.3" \; clear-history
+bind -n C-_ send-keys C-l \; run-shell "sleep 0.3" \; clear-history
 bind k send-keys -R \; clear-history
 # bind prefix-r to rotate windows
 bind r rotate-window


### PR DESCRIPTION
## What

`bind -n C-k` in `home/tmux.conf` was swallowing **Ctrl+K** at the tmux root key table and rewriting it to Ctrl+L before any TUI app could see it — which broke the argus task switcher (and any other app that wants Ctrl+K).

This moves the clear-screen + `clear-history` macro off Ctrl+K onto **Ctrl+/**, bound as both `C-/` and `C-_` to cover the two ways terminals encode Ctrl+/. Ctrl+K now passes straight through to the running program.

```tmux
# clear window binding (C-/ ; bind both encodings since terminals send C-/ or C-_)
bind -n C-/ send-keys C-l \; run-shell "sleep 0.3" \; clear-history
bind -n C-_ send-keys C-l \; run-shell "sleep 0.3" \; clear-history
```

## Why on master

This change was already live in the running tmux server and committed to the `root` branch of the main checkout, but `root` is a stale shadow of `master` and this is the only genuinely new commit on it. Landing it here puts it on the primary branch.

## Verification note

If your terminal uses the Kitty keyboard protocol (ghostty, kitty, recent WezTerm/foot), Ctrl+/ may arrive as a CSI-u sequence that neither `C-/` nor `C-_` catches — confirm Ctrl+/ actually clears, and switch to a plain Ctrl+letter if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>