### PR TITLE
fix(pr): keep .context phase artifacts out of PR diffs

### DIFF
--- a/agents/skills/_shared/resources/phase-protocol.md
+++ b/agents/skills/_shared/resources/phase-protocol.md
@@ -25,7 +25,11 @@ think → critique → plan → build → review → test → ship → land
 .context/phases/
 ```
 
-Create with `mkdir -p .context/phases` before writing. This directory is per-worktree and gitignored.
+Create with `mkdir -p .context/phases` before writing. This directory is per-worktree, agent-local scratch — it is **not** reviewable content.
+
+**Never `git add` or commit phase artifacts into a PR.** They are for cross-phase continuity, not for reviewers. A `ship-*.md` (or any `{phase}-*.md`) showing up in a PR diff is a defect — reviewers flag it, and it costs an extra review + force-push cycle. When committing, stage only the real change; leave `.context/` untouched.
+
+Most repos do not gitignore `.context/`, so `git add -A` or `git add .` will sweep these files in. Either stage files explicitly (avoid `git add -A`/`git add .`), or, if a repo genuinely needs `.context/` tracked, add `.context/` to that repo's `.gitignore` rather than committing the artifacts. Do not assume the directory is already gitignored.
 
 ## Naming Convention
 

--- a/agents/skills/_shared/resources/phase-protocol.md
+++ b/agents/skills/_shared/resources/phase-protocol.md
@@ -29,7 +29,7 @@ Create with `mkdir -p .context/phases` before writing. This directory is per-wor
 
 **Never `git add` or commit phase artifacts into a PR.** They are for cross-phase continuity, not for reviewers. A `ship-*.md` (or any `{phase}-*.md`) showing up in a PR diff is a defect — reviewers flag it, and it costs an extra review + force-push cycle. When committing, stage only the real change; leave `.context/` untouched.
 
-Most repos do not gitignore `.context/`, so `git add -A` or `git add .` will sweep these files in. Either stage files explicitly (avoid `git add -A`/`git add .`), or, if a repo genuinely needs `.context/` tracked, add `.context/` to that repo's `.gitignore` rather than committing the artifacts. Do not assume the directory is already gitignored.
+Most repos do not gitignore `.context/`, so `git add -A` or `git add .` will sweep these files in. Do not assume the directory is already gitignored. Use either safeguard: stage files explicitly (avoid `git add -A`/`git add .`), or add `.context/` to the repo's `.gitignore` so the artifacts can never be swept in.
 
 ## Naming Convention
 
@@ -88,3 +88,5 @@ After `/merge` completes, optionally move artifacts to preserve history:
 mkdir -p .context/phases/archive/{branch}-{ts}
 mv .context/phases/*.md .context/phases/archive/{branch}-{ts}/
 ```
+
+The archive stays under `.context/` — it is still agent-local scratch. The same rule applies: never `git add`/commit it into a PR (see [Artifact Directory](#artifact-directory) above).

--- a/agents/skills/pr/SKILL.md
+++ b/agents/skills/pr/SKILL.md
@@ -20,6 +20,8 @@ This skill participates in a phase chain. Read `~/.claude/skills/_shared/resourc
 
 **After the PR is created and green:** Write a `ship-{ts}.md` artifact to `.context/phases/` (create with `mkdir -p .context/phases`). The **Detail** section should include the PR URL, CI status, and any fixes applied. The **Handoff** section should note the PR number for `/merge`.
 
+**Do NOT `git add` or commit the `ship-{ts}.md` artifact (or any `.context/` file) into the PR.** It is agent-local scratch for cross-phase handoff, not reviewable content — a `ship-*.md` in the PR diff is a defect reviewers will flag. In every commit step above (Step 1 and Step 4b), stage only the real change; never use `git add -A` or `git add .` (they sweep in `.context/`). If a repo genuinely needs `.context/` tracked, add `.context/` to its `.gitignore` instead of committing the artifact.
+
 ## Your task
 
 Open a PR for the current branch, then loop until CI is fully green and all review comments are addressed. Do not return until the PR is in a mergeable, green state.

--- a/agents/skills/pr/SKILL.md
+++ b/agents/skills/pr/SKILL.md
@@ -20,7 +20,7 @@ This skill participates in a phase chain. Read `~/.claude/skills/_shared/resourc
 
 **After the PR is created and green:** Write a `ship-{ts}.md` artifact to `.context/phases/` (create with `mkdir -p .context/phases`). The **Detail** section should include the PR URL, CI status, and any fixes applied. The **Handoff** section should note the PR number for `/merge`.
 
-**Do NOT `git add` or commit the `ship-{ts}.md` artifact (or any `.context/` file) into the PR.** It is agent-local scratch for cross-phase handoff, not reviewable content — a `ship-*.md` in the PR diff is a defect reviewers will flag. In every commit step above (Step 1 and Step 4b), stage only the real change; never use `git add -A` or `git add .` (they sweep in `.context/`). If a repo genuinely needs `.context/` tracked, add `.context/` to its `.gitignore` instead of committing the artifact.
+**Do NOT `git add` or commit the `ship-{ts}.md` artifact (or any `.context/` file) into the PR.** It is agent-local scratch for cross-phase handoff, not reviewable content — a `ship-*.md` in the PR diff is a defect reviewers will flag. In every commit step below (Step 1 and Step 4b), stage only the real change; never use `git add -A` or `git add .` (they sweep in `.context/`). As a belt-and-suspenders safeguard, add `.context/` to the repo's `.gitignore` so the artifact can never be swept in.
 
 ## Your task
 
@@ -34,7 +34,7 @@ Determine the upstream repo slug (owner/name) — use `upstream` remote if it ex
 
 ### Step 1: Commit any uncommitted changes
 
-If there are uncommitted changes (check git status), stage and commit them with an appropriate message before proceeding. **Do this before anything else** — uncommitted changes are work the user wants shipped.
+If there are uncommitted changes (check git status), stage and commit them with an appropriate message before proceeding. **Do this before anything else** — uncommitted changes are work the user wants shipped. Stage specific files (`git add <path>`), not `git add -A`/`git add .`, so `.context/` scratch never gets swept in.
 
 **Abort condition (only when NO PR exists):** After committing any uncommitted changes, if there are STILL no commits ahead of the default branch, stop and tell the user: "Nothing to ship — no PR exists and there are no commits on this branch."
 
@@ -197,7 +197,7 @@ Then use `gh pr checks <number> --repo <owner/repo>` to see the current state of
   - Use `mcp__github__get_job_logs` with `failed_only: true` and the workflow `run_id` to read the failure logs.
   - Analyze the failure. Read the relevant source files to understand the issue.
   - Fix the code. Make the minimal change needed to resolve the failure.
-  - Stage and commit the fix with a clear message describing what was fixed and why.
+  - Stage and commit the fix with a clear message describing what was fixed and why. Stage specific files (`git add <path>`), not `git add -A`/`git add .`, so `.context/` scratch never gets swept in.
 - Push all fixes with `git push`.
 
 #### 4c: Check for and resolve ALL review threads


### PR DESCRIPTION
The phase protocol wrote ship-{ts}.md (and other phase artifacts) to .context/phases/ and assumed that directory was gitignored. In repos that do not gitignore .context/, git add -A / git add . swept the artifact into the PR commit — reviewers flagged it, costing an extra review + force-push cycle.

- phase-protocol.md: phase artifacts are agent-local scratch; never git add/commit them into a PR. Stage explicitly or gitignore .context/. Archive section carries the same reminder.
- pr/SKILL.md: mirror the rule at the ship-{ts}.md step and inline at the Step 1 / Step 4b commit paths (stage specific files, not git add -A).

Co-Authored-By: Claude <noreply@anthropic.com>