### PR TITLE
feat(agents): put dev-tool dirs on Bash tool PATH so binaries resolve

### DIFF
--- a/.github/skill-tests/test_session_path.sh
+++ b/.github/skill-tests/test_session_path.sh
@@ -63,9 +63,27 @@ test_idempotent_across_repeated_fires() {
   _run_hook "$home" "$envfile"
   _run_hook "$home" "$envfile"
 
+  # grep -cF counts matching LINES; each export is one line, so this is the
+  # occurrence count. Exactly 1 = the second fire saw the line and skipped it.
   local gobin_lines
   gobin_lines=$(grep -cF "$home/go/bin:\$PATH" "$envfile")
   assert_eq "$gobin_lines" "1" "go/bin export should appear exactly once after two fires"
+}
+
+test_uses_gopath_fallback_when_gobin_unset() {
+  local home envfile
+  home=$(_setup_path_home)
+  envfile="$home/envfile"
+  mkdir -p "$home/custom-gopath/bin"
+
+  # GOBIN unset but GOPATH set: the hook should derive $GOPATH/bin, not ~/go/bin.
+  HOME="$home" GOBIN="" GOPATH="$home/custom-gopath" CLAUDE_ENV_FILE="$envfile" \
+    bash "$HOOK" </dev/null
+
+  local body
+  body=$(cat "$envfile")
+  assert_contains "$body" "export PATH=\"$home/custom-gopath/bin:\$PATH\"" "GOPATH/bin should be used when GOBIN is unset"
+  assert_not_contains "$body" "$home/go/bin:\$PATH" "default ~/go/bin should not be used when GOPATH is set"
 }
 
 test_respects_custom_gobin() {

--- a/.github/skill-tests/test_session_path.sh
+++ b/.github/skill-tests/test_session_path.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+source "$(dirname "$0")/harness.sh"
+
+# Hook lives outside agents/skills, so SCRIPTS_DIR (which points at
+# agents/skills) doesn't help — derive the hook path from the test file.
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../agents/hooks" && pwd)/session-start-path.sh"
+
+# Build an isolated fake HOME with go/bin + asdf shims present (but not cargo)
+# so we can assert which dirs the hook prepends. Returns the HOME path.
+_setup_path_home() {
+  local home
+  home=$(mktemp -d "${TMPDIR:-/tmp}/skill-test-XXXXXX")
+  _TMPDIRS+=("$home")
+  mkdir -p "$home/go/bin" "$home/.asdf/shims"
+  # Deliberately omit "$home/.cargo/bin" — the hook should skip missing dirs.
+  echo "$home"
+}
+
+# Run the hook with a fresh CLAUDE_ENV_FILE and print that file's path.
+# Args: <fake-home> <env-file>
+_run_hook() {
+  local home="$1" envfile="$2"
+  # GOBIN unset so the hook falls back to $HOME/go/bin; HOME redirected.
+  HOME="$home" GOBIN="" GOPATH="" CLAUDE_ENV_FILE="$envfile" \
+    bash "$HOOK" </dev/null
+}
+
+test_prepends_existing_dev_dirs() {
+  local home envfile
+  home=$(_setup_path_home)
+  envfile="$home/envfile"
+
+  _run_hook "$home" "$envfile"
+
+  local body
+  body=$(cat "$envfile")
+  assert_contains "$body" "export PATH=\"$home/go/bin:\$PATH\"" "go/bin should be prepended"
+  assert_contains "$body" "export PATH=\"$home/.asdf/shims:\$PATH\"" "asdf shims should be prepended"
+  assert_not_contains "$body" "$home/.cargo/bin" "missing cargo dir should be skipped"
+}
+
+test_gobin_is_frontmost_after_sourcing() {
+  local home envfile
+  home=$(_setup_path_home)
+  envfile="$home/envfile"
+
+  _run_hook "$home" "$envfile"
+
+  # Source the env file from a clean PATH and confirm go/bin wins the front
+  # slot (mirrors ~/.zshenv ordering so go binaries bypass the asdf shims).
+  local resolved
+  resolved=$(PATH=/usr/bin:/bin bash -c "source '$envfile'; echo \"\$PATH\"" | cut -d: -f1)
+  assert_eq "$resolved" "$home/go/bin" "go/bin should be the frontmost PATH entry"
+}
+
+test_idempotent_across_repeated_fires() {
+  local home envfile
+  home=$(_setup_path_home)
+  envfile="$home/envfile"
+
+  # SessionStart can fire multiple times in one session; the env file persists,
+  # so re-running must not duplicate export lines.
+  _run_hook "$home" "$envfile"
+  _run_hook "$home" "$envfile"
+
+  local gobin_lines
+  gobin_lines=$(grep -cF "$home/go/bin:\$PATH" "$envfile")
+  assert_eq "$gobin_lines" "1" "go/bin export should appear exactly once after two fires"
+}
+
+test_respects_custom_gobin() {
+  local home envfile
+  home=$(_setup_path_home)
+  envfile="$home/envfile"
+  mkdir -p "$home/custom-gobin"
+
+  HOME="$home" GOBIN="$home/custom-gobin" GOPATH="" CLAUDE_ENV_FILE="$envfile" \
+    bash "$HOOK" </dev/null
+
+  local body
+  body=$(cat "$envfile")
+  assert_contains "$body" "export PATH=\"$home/custom-gobin:\$PATH\"" "custom GOBIN should be honored"
+  assert_not_contains "$body" "$home/go/bin:\$PATH" "default go/bin should not be used when GOBIN is set"
+}
+
+test_noop_without_env_file() {
+  local home
+  home=$(_setup_path_home)
+
+  # No CLAUDE_ENV_FILE (e.g. a hook event that doesn't provide one): the hook
+  # must exit cleanly without writing anything.
+  local out exit_code=0
+  out=$(HOME="$home" CLAUDE_ENV_FILE="" bash "$HOOK" </dev/null 2>&1) || exit_code=$?
+  assert_eq "$exit_code" "0" "hook should exit 0 when CLAUDE_ENV_FILE is unset"
+  assert_eq "$out" "" "hook should produce no output when CLAUDE_ENV_FILE is unset"
+}
+
+run_tests

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ dots docker stop-all     # Stop all Docker containers
 
 | Component | What it installs |
 |-----------|------------------|
-| `agents` | Agent skills, custom agents, hooks, and status line (symlinks `agents/skills/` → `~/.claude/skills/` + `~/.agents/skills/`, `agents/custom/` → `~/.claude/agents/`, registers SessionStart/SessionEnd/PostToolUse hooks and status line in `~/.claude/settings.json`) |
+| `agents` | Agent skills, custom agents, hooks, and status line (symlinks `agents/skills/` → `~/.claude/skills/` + `~/.agents/skills/`, `agents/custom/` → `~/.claude/agents/`, registers SessionStart/SessionEnd/PostToolUse hooks and status line in `~/.claude/settings.json`; one SessionStart hook prepends dev-tool bin dirs — `go/bin`, cargo, asdf shims — onto the Bash tool's `PATH` so binaries like `tts` resolve by bare name) |
 | `bin` | Custom shell scripts and Go utilities to `~/bin` |
 | `git` | `.gitconfig`, `.gitignore_global`, git extensions |
 | `home` | Dotfiles symlinked to `~/` (`.zshrc`, `.vimrc`, `.tmux.conf`, `.gitconfig`, etc.) |

--- a/agents/hooks/session-start-path.sh
+++ b/agents/hooks/session-start-path.sh
@@ -15,6 +15,10 @@
 #
 #   https://code.claude.com/docs/en/tools  (Bash tool behavior)
 #   https://code.claude.com/docs/en/hooks  (persist environment variables)
+#
+# Unlike the memory hook, this one prints nothing: per the docs, the
+# persist-env-vars pattern is a SessionStart hook that writes to
+# $CLAUDE_ENV_FILE and exits 0 with no stdout — no JSON envelope is required.
 set -euo pipefail
 
 # Drain stdin (Claude Code sends a JSON envelope we don't need here).
@@ -26,8 +30,9 @@ cat >/dev/null
 
 # Dev-tool bin dirs to prepend, in SOURCE order. The file is sourced top to
 # bottom and every line does `export PATH="$dir:$PATH"`, so the LAST line wins
-# the frontmost slot. Ordering mirrors ~/.zshenv, where $GOBIN sits ahead of
-# the asdf shims so go-installed binaries bypass the shims.
+# the frontmost slot (written A, B, C → after sourcing: C:B:A:$original).
+# Ordering mirrors ~/.zshenv, where $GOBIN sits ahead of the asdf shims so
+# go-installed binaries bypass the shims.
 gobin="${GOBIN:-${GOPATH:-$HOME/go}/bin}"
 dirs=(
   "$HOME/.cargo/bin"   # rust (cargo install)
@@ -39,6 +44,10 @@ for dir in "${dirs[@]}"; do
   # Skip dirs that don't exist so we never add dead PATH entries on machines
   # without that toolchain installed.
   [ -d "$dir" ] || continue
+  # Defensive: a literal double-quote in the path would break the generated
+  # `export PATH="…"` line when sourced. Real paths never contain one, but
+  # skip rather than emit invalid shell (this is a public repo).
+  case "$dir" in *'"'*) continue ;; esac
   # `$PATH` stays literal so it expands when the env file is sourced, not now.
   line="export PATH=\"$dir:\$PATH\""
   # Idempotent across repeated SessionStart fires within one session: the env

--- a/agents/hooks/session-start-path.sh
+++ b/agents/hooks/session-start-path.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Hook: SessionStart — make dev-tool bin dirs resolve in the Bash tool.
+#
+# Claude Code builds the Bash tool's PATH from the process that launched Claude
+# Code (often a daemon such as Argus), NOT from the user's interactive shell.
+# At session start it sources ~/.zshrc only to capture aliases, functions, and
+# shell options — PATH exports there (and in ~/.zshenv) are dropped. So
+# go-installed binaries like `tts` fail to resolve by bare name in the
+# non-interactive Bash tool shell, even though they run fine by absolute path.
+#
+# The supported fix (per Claude Code docs) is to append `export` lines to the
+# file named by $CLAUDE_ENV_FILE, which Claude Code sources before every
+# subsequent Bash command. Because the file is sourced, `$PATH` expands and the
+# inherited PATH is preserved — we prepend dev-tool dirs, never clobber it.
+#
+#   https://code.claude.com/docs/en/tools  (Bash tool behavior)
+#   https://code.claude.com/docs/en/hooks  (persist environment variables)
+set -euo pipefail
+
+# Drain stdin (Claude Code sends a JSON envelope we don't need here).
+cat >/dev/null
+
+# Only meaningful when Claude Code provides the env file (SessionStart, Setup,
+# CwdChanged, FileChanged hooks). Fail soft otherwise so the hook is a no-op.
+[ -n "${CLAUDE_ENV_FILE:-}" ] || exit 0
+
+# Dev-tool bin dirs to prepend, in SOURCE order. The file is sourced top to
+# bottom and every line does `export PATH="$dir:$PATH"`, so the LAST line wins
+# the frontmost slot. Ordering mirrors ~/.zshenv, where $GOBIN sits ahead of
+# the asdf shims so go-installed binaries bypass the shims.
+gobin="${GOBIN:-${GOPATH:-$HOME/go}/bin}"
+dirs=(
+  "$HOME/.cargo/bin"   # rust (cargo install)
+  "$HOME/.asdf/shims"  # asdf-managed runtimes
+  "$gobin"             # go install targets (tts, etc.) — frontmost
+)
+
+for dir in "${dirs[@]}"; do
+  # Skip dirs that don't exist so we never add dead PATH entries on machines
+  # without that toolchain installed.
+  [ -d "$dir" ] || continue
+  # `$PATH` stays literal so it expands when the env file is sourced, not now.
+  line="export PATH=\"$dir:\$PATH\""
+  # Idempotent across repeated SessionStart fires within one session: the env
+  # file persists, so only append an export the file doesn't already have.
+  if ! grep -qF -- "$line" "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    printf '%s\n' "$line" >> "$CLAUDE_ENV_FILE"
+  fi
+done

--- a/cli/commands/install/agents.go
+++ b/cli/commands/install/agents.go
@@ -38,6 +38,9 @@ func Agents() {
 	// Register Argus KB memory injection on SessionStart
 	registerSessionStartMemoryHook()
 
+	// Register dev-tool PATH injection on SessionStart
+	registerSessionStartPathHook()
+
 	// Register session-end raw capture into memory/inbox/
 	registerSessionEndCaptureHook()
 
@@ -204,6 +207,19 @@ func registerSessionStartMemoryHook() {
 		"SessionStart",
 		"agents/hooks/session-start-memory.sh",
 		"Registered Argus KB memory injection hook (SessionStart)",
+	)
+}
+
+// registerSessionStartPathHook prepends dev-tool bin dirs (go/bin, cargo,
+// asdf shims) onto the Bash tool's PATH via $CLAUDE_ENV_FILE so go-installed
+// binaries like `tts` resolve by bare name. Claude Code builds the Bash tool
+// PATH from its launch environment (often a daemon) and ignores ~/.zshenv, so
+// this hook is the supported way to restore those dirs.
+func registerSessionStartPathHook() {
+	registerSessionHook(
+		"SessionStart",
+		"agents/hooks/session-start-path.sh",
+		"Registered dev-tool PATH hook (SessionStart)",
 	)
 }
 

--- a/cli/commands/install/agents_test.go
+++ b/cli/commands/install/agents_test.go
@@ -1,0 +1,121 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/drn/dots/pkg/path"
+)
+
+// path.SetHome is package-global state. Tests in this file MUST NOT call
+// t.Parallel() — see the note in root_test.go.
+
+// setupClaudeHome points DOTS and HOME at temp dirs and creates ~/.claude so
+// settings mutation has somewhere to write. Returns the settings.json path.
+func setupClaudeHome(t *testing.T) string {
+	t.Helper()
+	dots := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("DOTS", dots)
+	path.SetHome(home)
+	t.Cleanup(func() { path.SetHome("") })
+
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatalf("mkdir .claude: %s", err)
+	}
+	return filepath.Join(home, ".claude", "settings.json")
+}
+
+// sessionStartCommands returns every inner command string registered under the
+// SessionStart hook event in the given settings file.
+func sessionStartCommands(t *testing.T, settingsPath string) []string {
+	t.Helper()
+	settings := readSettings(t, settingsPath)
+
+	hooks, _ := settings["hooks"].(map[string]any)
+	entries, _ := hooks["SessionStart"].([]any)
+
+	var cmds []string
+	for _, e := range entries {
+		entry, _ := e.(map[string]any)
+		inner, _ := entry["hooks"].([]any)
+		for _, h := range inner {
+			cmd, _ := h.(map[string]any)
+			if s, ok := cmd["command"].(string); ok {
+				cmds = append(cmds, s)
+			}
+		}
+	}
+	return cmds
+}
+
+// countContaining counts command strings that mention needle.
+func countContaining(cmds []string, needle string) int {
+	n := 0
+	for _, c := range cmds {
+		if strings.Contains(c, needle) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestRegisterSessionStartPathHook_AddsHook(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+
+	registerSessionStartPathHook()
+
+	cmds := sessionStartCommands(t, settingsPath)
+	if got := countContaining(cmds, "agents/hooks/session-start-path.sh"); got != 1 {
+		t.Fatalf("session-start-path.sh registered %d times, want 1 (cmds=%v)", got, cmds)
+	}
+}
+
+func TestRegisterSessionStartPathHook_Idempotent(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+
+	registerSessionStartPathHook()
+	registerSessionStartPathHook()
+
+	cmds := sessionStartCommands(t, settingsPath)
+	if got := countContaining(cmds, "agents/hooks/session-start-path.sh"); got != 1 {
+		t.Fatalf("session-start-path.sh registered %d times after re-run, want 1 (cmds=%v)", got, cmds)
+	}
+}
+
+func TestRegisterSessionStartPathHook_CoexistsWithMemoryHook(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+
+	// Both hooks live under SessionStart and must not collide: dedup is by
+	// inner command string, and the two scripts differ.
+	registerSessionStartMemoryHook()
+	registerSessionStartPathHook()
+
+	cmds := sessionStartCommands(t, settingsPath)
+	if got := countContaining(cmds, "agents/hooks/session-start-memory.sh"); got != 1 {
+		t.Errorf("memory hook present %d times, want 1 (cmds=%v)", got, cmds)
+	}
+	if got := countContaining(cmds, "agents/hooks/session-start-path.sh"); got != 1 {
+		t.Errorf("path hook present %d times, want 1 (cmds=%v)", got, cmds)
+	}
+}
+
+func TestRegisterSessionStartPathHook_CommandShape(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+
+	registerSessionStartPathHook()
+
+	want := "bash \"" + path.FromDots("agents/hooks/session-start-path.sh") + "\""
+	cmds := sessionStartCommands(t, settingsPath)
+	found := false
+	for _, c := range cmds {
+		if c == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no SessionStart command equal to %q (cmds=%v)", want, cmds)
+	}
+}

--- a/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/proposal.md
+++ b/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/proposal.md
@@ -1,0 +1,42 @@
+# Change: Add dev-tool PATH hook for Claude Code's Bash tool
+
+## Why
+Bare `tts` (and other go-installed binaries) fail with `command not found` inside
+Claude Code's Bash tool, even though `/Users/<user>/go/bin/tts` runs fine by absolute
+path. The global `~/.claude/CLAUDE.md` TTS convention (`tts -s 1.1 "<summary>"`)
+assumes bare `tts` resolves, so it breaks in every Bash-tool call.
+
+Root cause: Claude Code builds the Bash tool's PATH from the process that launched it
+(often a daemon such as Argus, whose PATH lacks `go/bin`), NOT from the user's
+interactive shell. Per the Claude Code docs, at session start it sources `~/.zshrc`
+only to capture **aliases, functions, and shell options** — PATH exports there (and in
+`~/.zshenv`) are dropped. So the existing `~/.zshenv` `go/bin` export (shipped in
+commit `95ac7d4`) cannot reach the Bash tool.
+
+Two non-fixes were ruled out:
+- **`settings.json` `env.PATH`** *replaces* PATH wholesale and performs no `$PATH`
+  expansion, so it would clobber the inherited PATH (including Claude Code's plugin
+  bin dirs). Not viable.
+- **`~/.zshenv` / `~/.zshrc`** additions are not captured for the Bash tool (see above).
+
+The supported mechanism is `$CLAUDE_ENV_FILE`: a SessionStart hook appends `export`
+lines to it, and Claude Code sources that file before every subsequent Bash command.
+Because it is sourced, `$PATH` expands and the inherited PATH is preserved.
+
+## What Changes
+- Add `agents/hooks/session-start-path.sh`: a SessionStart hook that prepends existing
+  dev-tool bin dirs (`$GOBIN`/`~/go/bin`, `~/.cargo/bin`, `~/.asdf/shims`) onto PATH by
+  appending `export PATH="$dir:$PATH"` lines to `$CLAUDE_ENV_FILE`. It skips dirs that
+  don't exist, is idempotent across repeated SessionStart fires, and orders entries so
+  `go/bin` lands frontmost (mirroring `~/.zshenv`, where `$GOBIN` precedes the asdf
+  shims).
+- Register the hook in `dots install agents` via a new `registerSessionStartPathHook()`,
+  reusing the existing idempotent `registerSessionHook` machinery.
+
+## Impact
+- Affected specs: `agent-config-install` (ADDED: Dev-Tool PATH Hook Registration)
+- Affected code: `cli/commands/install/agents.go`, `agents/hooks/session-start-path.sh`
+- Tests: `cli/commands/install/agents_test.go` (registration + idempotency),
+  `.github/skill-tests/test_session_path.sh` (hook script behavior)
+- No change to credential handling; the hook only prepends directories that already
+  exist on the machine and never writes secrets.

--- a/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/specs/agent-config-install/spec.md
+++ b/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/specs/agent-config-install/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Dev-Tool PATH Hook Registration
+
+The `agents` installer SHALL register a `SessionStart` hook running
+`agents/hooks/session-start-path.sh` via `bash`, so that go-installed and other
+dev-tool binaries resolve by bare name in Claude Code's Bash tool. The hook SHALL
+append `export PATH="<dir>:$PATH"` lines to the file named by `$CLAUDE_ENV_FILE`
+for each of `$GOBIN` (falling back to `$GOPATH/bin`, then `~/go/bin`),
+`~/.cargo/bin`, and `~/.asdf/shims`. The hook SHALL skip directories that do not
+exist, SHALL order entries so `go/bin` is the frontmost PATH entry after the file
+is sourced, SHALL be idempotent across repeated SessionStart fires within a
+session, and SHALL be a no-op when `$CLAUDE_ENV_FILE` is unset. Registration SHALL
+reuse the idempotent session-hook machinery, deduplicating by inner command string
+so it coexists with the existing memory hook.
+
+#### Scenario: Dev-tool PATH hook registered
+
+- **WHEN** the `agents` installer runs against settings without the dev-tool PATH hook
+- **THEN** a `SessionStart` hook running `agents/hooks/session-start-path.sh` is added, alongside any existing `SessionStart` hooks
+
+#### Scenario: Existing dev-tool dirs prepended
+
+- **WHEN** the hook runs with `$CLAUDE_ENV_FILE` set and `~/go/bin` and `~/.asdf/shims` present but `~/.cargo/bin` absent
+- **THEN** the env file gains `export PATH="…/go/bin:$PATH"` and `export PATH="…/.asdf/shims:$PATH"` lines, no `~/.cargo/bin` line, and after sourcing the file `go/bin` is the frontmost PATH entry
+
+#### Scenario: Idempotent across repeated fires
+
+- **WHEN** the hook runs twice against the same `$CLAUDE_ENV_FILE`
+- **THEN** each dev-tool `export PATH` line appears exactly once
+
+#### Scenario: No env file is a no-op
+
+- **WHEN** the hook runs without `$CLAUDE_ENV_FILE` set
+- **THEN** it exits 0 and writes nothing

--- a/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/tasks.md
+++ b/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Add dev-tool PATH hook
+
+## 1. Hook script
+- [x] 1.1 Add `agents/hooks/session-start-path.sh` that appends `export PATH="$dir:$PATH"` to `$CLAUDE_ENV_FILE` for `$GOBIN`/`~/go/bin`, `~/.cargo/bin`, `~/.asdf/shims`
+- [x] 1.2 Skip dirs that don't exist; honor a custom `$GOBIN`/`$GOPATH`; order so `go/bin` is frontmost
+- [x] 1.3 Make it idempotent across repeated SessionStart fires (no duplicate lines) and a no-op when `$CLAUDE_ENV_FILE` is unset
+
+## 2. Installer registration
+- [x] 2.1 Add `registerSessionStartPathHook()` in `cli/commands/install/agents.go` and call it from `Agents()`
+- [x] 2.2 Reuse `registerSessionHook` so registration is deduped by inner command string and coexists with the memory hook
+
+## 3. Tests
+- [x] 3.1 Go tests: hook registered once, idempotent on re-run, coexists with memory hook, correct command shape (`cli/commands/install/agents_test.go`)
+- [x] 3.2 Skill test: prepends existing dirs, skips missing cargo, go/bin frontmost after sourcing, idempotent, honors custom `$GOBIN`, no-op without env file (`.github/skill-tests/test_session_path.sh`)
+
+## 4. Docs + validation
+- [x] 4.1 Update `README.md` agents-component description to mention the SessionStart PATH hook
+- [x] 4.2 `openspec validate add-dev-tool-path-hook --strict` passes
+
+## 5. Archive within this PR
+- [ ] 5.1 Merge the delta into `openspec/specs/agent-config-install/spec.md` and move the change to `openspec/changes/archive/<date>-add-dev-tool-path-hook/`

--- a/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/tasks.md
+++ b/openspec/changes/archive/2026-06-30-add-dev-tool-path-hook/tasks.md
@@ -18,4 +18,4 @@
 - [x] 4.2 `openspec validate add-dev-tool-path-hook --strict` passes
 
 ## 5. Archive within this PR
-- [ ] 5.1 Merge the delta into `openspec/specs/agent-config-install/spec.md` and move the change to `openspec/changes/archive/<date>-add-dev-tool-path-hook/`
+- [x] 5.1 Merge the delta into `openspec/specs/agent-config-install/spec.md` and move the change to `openspec/changes/archive/<date>-add-dev-tool-path-hook/`

--- a/openspec/specs/agent-config-install/spec.md
+++ b/openspec/specs/agent-config-install/spec.md
@@ -7,7 +7,9 @@ repository's reusable skills, custom agent types, and hooks are wired into Claud
 Code and Codex by symlinking directories and mutating `~/.claude/settings.json`.
 
 This spec documents the behavior that ships today.
+
 ## Requirements
+
 ### Requirement: Skill and Agent Symlinking
 
 The `agents` installer SHALL ensure `~/.claude` and `~/.agents` exist, then

--- a/openspec/specs/agent-config-install/spec.md
+++ b/openspec/specs/agent-config-install/spec.md
@@ -7,9 +7,7 @@ repository's reusable skills, custom agent types, and hooks are wired into Claud
 Code and Codex by symlinking directories and mutating `~/.claude/settings.json`.
 
 This spec documents the behavior that ships today.
-
 ## Requirements
-
 ### Requirement: Skill and Agent Symlinking
 
 The `agents` installer SHALL ensure `~/.claude` and `~/.agents` exist, then
@@ -90,3 +88,38 @@ when it exists, its current mode SHALL be preserved.
 
 - **WHEN** settings mutation adds a hook to a file with unrelated keys
 - **THEN** the unrelated keys are retained in the written file
+
+### Requirement: Dev-Tool PATH Hook Registration
+
+The `agents` installer SHALL register a `SessionStart` hook running
+`agents/hooks/session-start-path.sh` via `bash`, so that go-installed and other
+dev-tool binaries resolve by bare name in Claude Code's Bash tool. The hook SHALL
+append `export PATH="<dir>:$PATH"` lines to the file named by `$CLAUDE_ENV_FILE`
+for each of `$GOBIN` (falling back to `$GOPATH/bin`, then `~/go/bin`),
+`~/.cargo/bin`, and `~/.asdf/shims`. The hook SHALL skip directories that do not
+exist, SHALL order entries so `go/bin` is the frontmost PATH entry after the file
+is sourced, SHALL be idempotent across repeated SessionStart fires within a
+session, and SHALL be a no-op when `$CLAUDE_ENV_FILE` is unset. Registration SHALL
+reuse the idempotent session-hook machinery, deduplicating by inner command string
+so it coexists with the existing memory hook.
+
+#### Scenario: Dev-tool PATH hook registered
+
+- **WHEN** the `agents` installer runs against settings without the dev-tool PATH hook
+- **THEN** a `SessionStart` hook running `agents/hooks/session-start-path.sh` is added, alongside any existing `SessionStart` hooks
+
+#### Scenario: Existing dev-tool dirs prepended
+
+- **WHEN** the hook runs with `$CLAUDE_ENV_FILE` set and `~/go/bin` and `~/.asdf/shims` present but `~/.cargo/bin` absent
+- **THEN** the env file gains `export PATH="…/go/bin:$PATH"` and `export PATH="…/.asdf/shims:$PATH"` lines, no `~/.cargo/bin` line, and after sourcing the file `go/bin` is the frontmost PATH entry
+
+#### Scenario: Idempotent across repeated fires
+
+- **WHEN** the hook runs twice against the same `$CLAUDE_ENV_FILE`
+- **THEN** each dev-tool `export PATH` line appears exactly once
+
+#### Scenario: No env file is a no-op
+
+- **WHEN** the hook runs without `$CLAUDE_ENV_FILE` set
+- **THEN** it exits 0 and writes nothing
+


### PR DESCRIPTION
Bare `tts` (and other go-installed binaries) failed with `command not found` in
Claude Code's Bash tool. Claude Code builds the Bash tool PATH from its launch
environment (often a daemon such as Argus, lacking go/bin) and captures only
aliases/functions/shell-options from ~/.zshrc — PATH exports in ~/.zshrc/~/.zshenv
are dropped, and settings.json env.PATH replaces PATH wholesale with no expansion.

Add a SessionStart hook (agents/hooks/session-start-path.sh) that appends
`export PATH="$dir:$PATH"` for go/bin, cargo, and asdf shims to $CLAUDE_ENV_FILE
(sourced before each Bash command, so $PATH expands and is preserved). Skips
missing dirs, idempotent, go/bin frontmost, no-op without the env file. Registered
in `dots install agents` via registerSessionStartPathHook().

Includes Go + skill tests and an OpenSpec change (archived in-PR with the base
spec updated).

Co-Authored-By: Claude <noreply@anthropic.com>