### PR TITLE
Manage cleanupPeriodDays via dots install agents

### DIFF
--- a/cli/commands/install/agents.go
+++ b/cli/commands/install/agents.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
 	"github.com/drn/dots/cli/link"
@@ -300,8 +301,16 @@ func ensureScalarSetting(key string, value any, successMsg string) {
 
 // registerCleanupPeriod sets cleanupPeriodDays to 3 years so local Claude
 // Code session transcripts aren't cleaned up on the default 30-day window.
+// This trades a wider on-disk retention window (transcripts can contain
+// pasted secrets/tokens) for longer local history; it's a deliberate choice
+// for a personal machine, not an exfiltration risk since nothing leaves it.
 func registerCleanupPeriod() {
-	ensureScalarSetting("cleanupPeriodDays", 1095, "Set cleanupPeriodDays to 1095 (3 years)")
+	const cleanupPeriodDays = 1095
+	ensureScalarSetting(
+		"cleanupPeriodDays",
+		cleanupPeriodDays,
+		fmt.Sprintf("Set cleanupPeriodDays to %d (3 years)", cleanupPeriodDays),
+	)
 }
 
 func ensureDir(dir string) bool {

--- a/cli/commands/install/agents.go
+++ b/cli/commands/install/agents.go
@@ -49,6 +49,9 @@ func Agents() {
 
 	// Register status line
 	registerStatusLine()
+
+	// Manage local session transcript retention
+	registerCleanupPeriod()
 }
 
 // mutateSettings reads ~/.claude/settings.json, applies a mutation function,
@@ -269,6 +272,36 @@ func registerStatusLine() {
 	if changed {
 		log.Success("Registered status line (context usage)")
 	}
+}
+
+// ensureScalarSetting sets settings[key] = value in ~/.claude/settings.json
+// unless the existing value already matches. Equality is judged by JSON
+// marshaling both sides, so equivalent numeric encodings (e.g. int 1095 vs.
+// a float64 1095 decoded from disk) count as matching and don't trigger a
+// rewrite.
+func ensureScalarSetting(key string, value any, successMsg string) {
+	changed := mutateSettings(func(settings map[string]any) bool {
+		if existing, ok := settings[key]; ok {
+			existingJSON, err1 := json.Marshal(existing)
+			valueJSON, err2 := json.Marshal(value)
+			if err1 == nil && err2 == nil && string(existingJSON) == string(valueJSON) {
+				return false // already set
+			}
+		}
+
+		settings[key] = value
+		return true
+	})
+
+	if changed {
+		log.Success("%s", successMsg)
+	}
+}
+
+// registerCleanupPeriod sets cleanupPeriodDays to 3 years so local Claude
+// Code session transcripts aren't cleaned up on the default 30-day window.
+func registerCleanupPeriod() {
+	ensureScalarSetting("cleanupPeriodDays", 1095, "Set cleanupPeriodDays to 1095 (3 years)")
 }
 
 func ensureDir(dir string) bool {

--- a/cli/commands/install/agents_test.go
+++ b/cli/commands/install/agents_test.go
@@ -119,3 +119,61 @@ func TestRegisterSessionStartPathHook_CommandShape(t *testing.T) {
 		t.Errorf("no SessionStart command equal to %q (cmds=%v)", want, cmds)
 	}
 }
+
+func TestEnsureScalarSetting_SetsWhenAbsent(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+
+	ensureScalarSetting("cleanupPeriodDays", 1095, "set")
+
+	settings := readSettings(t, settingsPath)
+	if got := settings["cleanupPeriodDays"]; got != float64(1095) {
+		t.Fatalf("cleanupPeriodDays = %v, want 1095", got)
+	}
+}
+
+func TestEnsureScalarSetting_OverwritesWhenDifferent(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+	writeJSON(t, settingsPath, map[string]any{"cleanupPeriodDays": 30})
+
+	ensureScalarSetting("cleanupPeriodDays", 1095, "set")
+
+	settings := readSettings(t, settingsPath)
+	if got := settings["cleanupPeriodDays"]; got != float64(1095) {
+		t.Fatalf("cleanupPeriodDays = %v, want 1095", got)
+	}
+}
+
+func TestEnsureScalarSetting_NoopWhenMatching(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+	writeJSON(t, settingsPath, map[string]any{"cleanupPeriodDays": 1095})
+
+	before, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat before: %s", err)
+	}
+
+	ensureScalarSetting("cleanupPeriodDays", 1095, "set")
+
+	after, err := os.Stat(settingsPath)
+	if err != nil {
+		t.Fatalf("stat after: %s", err)
+	}
+	if !before.ModTime().Equal(after.ModTime()) {
+		t.Fatalf("settings.json was rewritten when value already matched")
+	}
+}
+
+func TestEnsureScalarSetting_PreservesOtherKeys(t *testing.T) {
+	settingsPath := setupClaudeHome(t)
+	writeJSON(t, settingsPath, map[string]any{"model": "opus"})
+
+	ensureScalarSetting("cleanupPeriodDays", 1095, "set")
+
+	settings := readSettings(t, settingsPath)
+	if got := settings["model"]; got != "opus" {
+		t.Fatalf("model = %v, want opus", got)
+	}
+	if got := settings["cleanupPeriodDays"]; got != float64(1095) {
+		t.Fatalf("cleanupPeriodDays = %v, want 1095", got)
+	}
+}

--- a/openspec/changes/archive/2026-08-12-add-scalar-setting-management/proposal.md
+++ b/openspec/changes/archive/2026-08-12-add-scalar-setting-management/proposal.md
@@ -1,0 +1,27 @@
+# Change: Manage scalar `~/.claude/settings.json` keys via `dots install agents`
+
+## Why
+
+Darren wants `cleanupPeriodDays` (local session transcript retention) set to
+1095 days (3 years) and kept that way across machines, the same way `dots
+install agents` already manages hooks and the status line. Today the
+installer only knows how to mutate `settings.hooks` and `settings.statusLine`
+— there's no primitive for a bare top-level scalar key, so this was set by
+hand instead of through dots.
+
+## What Changes
+
+- Add a generic `ensureScalarSetting(key, value, successMsg)` helper to the
+  `agents` installer, alongside the existing `mutateSettings` /
+  `registerMatcherHook` / `registerSessionHook` helpers. It sets
+  `settings[key] = value` when absent or different, and is a no-op when the
+  value already matches (compared via JSON marshaling, so `1095` and
+  `1095.0` are treated as equal).
+- Use it to set `cleanupPeriodDays` to `1095` on every `dots install agents`
+  run.
+
+## Impact
+
+- Affected specs: `agent-config-install`
+- Affected code: `cli/commands/install/agents.go`,
+  `cli/commands/install/agents_test.go`

--- a/openspec/changes/archive/2026-08-12-add-scalar-setting-management/specs/agent-config-install/spec.md
+++ b/openspec/changes/archive/2026-08-12-add-scalar-setting-management/specs/agent-config-install/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Scalar Setting Management
+
+The `agents` installer SHALL provide a generic mechanism to ensure a
+top-level scalar key in `~/.claude/settings.json` matches a configured value.
+The mechanism SHALL set the key when absent, overwrite it when the existing
+value differs, and leave `settings.json` unwritten when the existing value
+already matches the configured value (compared by JSON-marshaled
+representation, so equivalent numeric encodings such as `1095` and `1095.0`
+count as matching).
+
+#### Scenario: Key absent is set
+
+- **WHEN** the configured key is not present in `settings.json`
+- **THEN** it is added with the configured value
+
+#### Scenario: Drifted value is overwritten
+
+- **WHEN** the configured key is present with a value different from the configured value
+- **THEN** `settings.json` is rewritten with the configured value
+
+#### Scenario: Matching value is left untouched
+
+- **WHEN** the configured key already holds a JSON-equal value
+- **THEN** `settings.json` is not rewritten
+
+### Requirement: Local Transcript Retention Configuration
+
+The `agents` installer SHALL set `cleanupPeriodDays` to `1095` (3 years) in
+`~/.claude/settings.json` using the scalar setting management mechanism, so
+local Claude Code session transcript retention is consistently configured on
+every machine where `dots install agents` runs.
+
+#### Scenario: Retention period configured
+
+- **WHEN** the `agents` installer runs against settings without `cleanupPeriodDays`
+- **THEN** `cleanupPeriodDays` is set to `1095`
+
+#### Scenario: Re-running is idempotent
+
+- **WHEN** the `agents` installer runs again with `cleanupPeriodDays` already `1095`
+- **THEN** `settings.json` is left unchanged for that key

--- a/openspec/changes/archive/2026-08-12-add-scalar-setting-management/tasks.md
+++ b/openspec/changes/archive/2026-08-12-add-scalar-setting-management/tasks.md
@@ -1,0 +1,6 @@
+## 1. Implementation
+
+- [x] 1.1 Add `ensureScalarSetting(key string, value any, successMsg string)` to `cli/commands/install/agents.go`, built on `mutateSettings`, comparing existing vs. target value via `json.Marshal` equality
+- [x] 1.2 Add `registerCleanupPeriod()` calling `ensureScalarSetting("cleanupPeriodDays", 1095, ...)` and call it from `Agents()`
+- [x] 1.3 Add unit tests in `cli/commands/install/agents_test.go`: sets when absent, overwrites when different, no-op (no write) when already matching
+- [x] 1.4 Run `go install ./...`, `revive`, `go test ./...`, `qlty check --fix --level=low`, `qlty smells --all --no-snippets`

--- a/openspec/specs/agent-config-install/spec.md
+++ b/openspec/specs/agent-config-install/spec.md
@@ -7,9 +7,7 @@ repository's reusable skills, custom agent types, and hooks are wired into Claud
 Code and Codex by symlinking directories and mutating `~/.claude/settings.json`.
 
 This spec documents the behavior that ships today.
-
 ## Requirements
-
 ### Requirement: Skill and Agent Symlinking
 
 The `agents` installer SHALL ensure `~/.claude` and `~/.agents` exist, then
@@ -124,4 +122,46 @@ so it coexists with the existing memory hook.
 
 - **WHEN** the hook runs without `$CLAUDE_ENV_FILE` set
 - **THEN** it exits 0 and writes nothing
+
+### Requirement: Scalar Setting Management
+
+The `agents` installer SHALL provide a generic mechanism to ensure a
+top-level scalar key in `~/.claude/settings.json` matches a configured value.
+The mechanism SHALL set the key when absent, overwrite it when the existing
+value differs, and leave `settings.json` unwritten when the existing value
+already matches the configured value (compared by JSON-marshaled
+representation, so equivalent numeric encodings such as `1095` and `1095.0`
+count as matching).
+
+#### Scenario: Key absent is set
+
+- **WHEN** the configured key is not present in `settings.json`
+- **THEN** it is added with the configured value
+
+#### Scenario: Drifted value is overwritten
+
+- **WHEN** the configured key is present with a value different from the configured value
+- **THEN** `settings.json` is rewritten with the configured value
+
+#### Scenario: Matching value is left untouched
+
+- **WHEN** the configured key already holds a JSON-equal value
+- **THEN** `settings.json` is not rewritten
+
+### Requirement: Local Transcript Retention Configuration
+
+The `agents` installer SHALL set `cleanupPeriodDays` to `1095` (3 years) in
+`~/.claude/settings.json` using the scalar setting management mechanism, so
+local Claude Code session transcript retention is consistently configured on
+every machine where `dots install agents` runs.
+
+#### Scenario: Retention period configured
+
+- **WHEN** the `agents` installer runs against settings without `cleanupPeriodDays`
+- **THEN** `cleanupPeriodDays` is set to `1095`
+
+#### Scenario: Re-running is idempotent
+
+- **WHEN** the `agents` installer runs again with `cleanupPeriodDays` already `1095`
+- **THEN** `settings.json` is left unchanged for that key
 


### PR DESCRIPTION
Adds a generic ensureScalarSetting helper to the agents installer's
settings.json mutation machinery, and uses it to enforce
cleanupPeriodDays=1095 (3 years) on every dots install agents run
instead of that key being set by hand. Includes the approved
OpenSpec change (archived into the base spec in this same PR).

Co-Authored-By: Claude <noreply@anthropic.com>