### PR TITLE
Add deploy-audit and deploy-validate skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,8 @@ When the user's message matches a phrase below, read and follow the correspondin
 | "loop", "poll", "recurring", "every N minutes", "babysit", "monitor periodically", "run on interval" | `agents/skills/loop/SKILL.md` |
 | "compare PRs", "combine PRs", "combine these PRs", "cherry-pick between PRs", "competing implementations", "competing PRs" | `agents/skills/combine-prs/SKILL.md` |
 | "open a PR", "address review comments", "address review feedback", "fix CI failures on the PR", "wait for CI", "address PR comments" | `agents/skills/pr/SKILL.md` |
+| "audit pending commits", "check deploy risk", "review what's shipping", "audit deploy risk", "deploy audit" | `agents/skills/deploy-audit/SKILL.md` |
+| "validate a deploy", "check post-deploy health", "confirm production rollout is healthy", "deploy validate", "post-deploy check" | `agents/skills/deploy-validate/SKILL.md` |
 | "just address comments", "only address comments", "resolve review threads", "reply to PR comments", "clear bot comments", "address comments without re-running CI" | `agents/skills/address-comments/SKILL.md` |
 | "improve skills", "capture learnings", "upgrade context", "learn from session" | `agents/skills/improve/SKILL.md` |
 | "amend", "amend commit", "rewrite commit message", "improve commit message", "fix commit message" | `agents/skills/amend/SKILL.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,8 @@ Filter to changed files only by replacing `--all` with `--upstream=origin/master
 
 If `qlty` panics with `failed to create initial log file ... PermissionDenied` under a sandboxed agent, redirect its log dir by overriding `HOME`: `HOME=/tmp/qlty-home qlty smells --all`. The Claude Code sandbox blocks writes to `~/.qlty/logs` even though the user owns the directory (`com.apple.provenance` xattr from a different process).
 
+If instead you get `command not found: qlty` in the Bash tool despite `qlty` working in a normal terminal, its install dir (`~/.qlty/bin`) isn't on the Bash tool's PATH — invoke it by full path (`~/.qlty/bin/qlty`) or see `/bash-tool-path` to fix PATH for the session.
+
 ## Pre-Completion Checklist
 
 Before considering any task complete, run the full test suite:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dots docker stop-all     # Stop all Docker containers
 
 ## Agent Skills
 
-Dots includes 73 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
+Dots includes 71 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
 
 | Skill | Description |
 |-------|-------------|
@@ -195,7 +195,7 @@ Run `dots install agents` to symlink them to `~/.claude/agents/`.
 ├── pi/                        # pi.dev coding agent config (models.json only)
 │
 ├── agents/                    # Agent configuration
-│   ├── skills/                # 73 reusable skills (SKILL.md per skill)
+│   ├── skills/                # 71 reusable skills (SKILL.md per skill)
 │   └── custom/                # 3 custom agent types (.md per agent)
 │       └── tests/             # Skill test suite
 │

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dots docker stop-all     # Stop all Docker containers
 
 ## Agent Skills
 
-Dots includes 71 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
+Dots includes 73 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
 
 | Skill | Description |
 |-------|-------------|
@@ -78,6 +78,8 @@ Dots includes 71 reusable slash-command skills for AI coding agents, following t
 | `/address-comments` | Walk every unresolved review thread on a PR — triage, reply with rationale, fix if warranted, and resolve |
 | `/review` | Code review panel for current branch changes |
 | `/deploy` | Deploy master to production with version tags |
+| `/deploy-audit` | Audit commits pending between a base branch and a deployed branch/tag for migration, config-wiring, flag, and schema risk, then open the GitHub compare diff |
+| `/deploy-validate` | Post-deploy health check across CI, rollout, error tracking, and monitoring, correlated against deploy timing to filter pre-existing noise |
 | `/merge` | Merge current branch to master via GitHub PR |
 | `/debug` | Multi-agent competing hypotheses debugging |
 | `/dev` | Multi-agent iterative development with parallel testing and code review |
@@ -193,7 +195,7 @@ Run `dots install agents` to symlink them to `~/.claude/agents/`.
 ├── pi/                        # pi.dev coding agent config (models.json only)
 │
 ├── agents/                    # Agent configuration
-│   ├── skills/                # 71 reusable skills (SKILL.md per skill)
+│   ├── skills/                # 73 reusable skills (SKILL.md per skill)
 │   └── custom/                # 3 custom agent types (.md per agent)
 │       └── tests/             # Skill test suite
 │

--- a/agents/skills/deploy-audit/SKILL.md
+++ b/agents/skills/deploy-audit/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: deploy-audit
+description: Audit every commit pending between a base branch and a deployed branch/tag for deploy risk (migrations, config/secret wiring completeness, feature-flag defaults, schema parity), then open the GitHub compare diff. Use when asked to audit pending commits, check deploy risk, review what is about to ship, or before opening a deploy PR or shipping to production.
+---
+
+# Pre-Deploy Risk Audit
+
+Audit the commits pending between a base branch and a deployed branch/tag,
+assess the risk of each change, and open the GitHub compare diff for human
+review. This is an informational audit — it does not block or change anything
+on its own.
+
+## Arguments
+
+- `$ARGUMENTS` - Optional: `<base>..<deployed>` (e.g. `master..production`), or
+  just the deployed ref if the base is the repo's default branch. If omitted,
+  detect candidates from context below and ask the user to confirm.
+
+## Context
+
+- Remote: !`git remote get-url origin 2>/dev/null | head -1`
+- Default branch: !`git branch -r 2>/dev/null | grep -oE 'origin/(main|master)' | head -1`
+- Remote branches: !`git branch -r 2>/dev/null | grep -viE 'HEAD|dependabot' | head -30`
+- Recent tags: !`git tag --sort=-creatordate 2>/dev/null | head -10`
+
+## Instructions
+
+### Step 1: Determine the two refs
+
+Parse `$ARGUMENTS` for `<base>..<deployed>`. If only one ref is given, treat it
+as the deployed ref and use the detected default branch as base. If nothing is
+given, look at the remote branches/tags in Context above for likely
+candidates (a `production`/`release`/`deploy` branch, or the most recent tag)
+and ask the user to confirm the base and deployed refs before proceeding.
+
+Run `git fetch origin` for both refs to ensure they are current.
+
+### Step 2: Enumerate pending commits
+
+```
+git log --oneline <deployed>..<base>
+git diff --stat <deployed>..<base>
+```
+
+If this returns nothing, report "Nothing pending — `<deployed>` and `<base>`
+are in sync" and stop.
+
+Read full commit messages for risk signal:
+
+```
+git log --format='%H %s%n%b%n---' <deployed>..<base>
+```
+
+Commit bodies often carry the actual risk context (design rationale, what a
+migration does, why a flag was added) that the subject line does not.
+
+### Step 3: Assess migration safety
+
+If the diff touches migration files (schema migrations, database migration
+directories — detect the project's convention rather than assuming one path),
+read each new migration and classify it:
+
+- **Additive/safe**: new nullable column, new table, new index created
+  concurrently/online
+- **Requires care**: backfill needed, column made non-nullable, default value
+  added to an existing large table
+- **Destructive**: column/table drop, rename, type change without a
+  compatibility shim
+
+Flag anything in the latter two categories explicitly.
+
+### Step 4: Check schema parity
+
+If the project maintains more than one copy of a schema file (a canonical
+schema plus mirrored/generated copies used by other services or packages —
+check the project's own docs/rules for this convention, or search for
+multiple files with the same schema filename), diff the canonical version
+against every mirror. Flag any mismatch in version or content.
+
+If the project has no such mirrored-schema convention, skip this step and
+say so.
+
+### Step 5: Trace config and secret wiring
+
+For every new environment variable or secret introduced by the diff, trace it
+through the **full chain** the project uses to get a value from
+infrastructure config into a running process — for example: an IaC variable
+declaration, through any module wiring, into the per-environment secret
+definitions, into the actual task/service/container definition that reads it.
+
+A secret or parameter existing in a vault/parameter store is not the same as
+it being wired anywhere a running process reads it — check for a reference at
+every layer, not just that the value was provisioned. This is the single
+highest-value check in this audit: a half-wired chain (defined but never
+referenced downstream) will not be caught by `terraform plan` or similar and
+fails silently in production.
+
+If the project has no IaC/config-chain convention to trace, skip this step
+and say so.
+
+### Step 6: Check feature-flag defaults
+
+If the diff introduces calls to a feature-flag SDK for a new flag key, look up
+that flag's default/targeting state in whatever flag-management tooling the
+project has available (search with ToolSearch for a feature-flag MCP tool, or
+check for a flag-provider CLI). Confirm new flags default to **off**, or note
+explicitly if a new flag is live-by-default and why.
+
+If no flag-management tooling is discoverable, skip this step and say so.
+
+### Step 7: Open the compare diff
+
+Derive `<org>/<repo>` from the remote URL in Context and open:
+
+```
+https://github.com/<org>/<repo>/compare/<deployed>...<base>
+```
+
+On macOS use `open "<url>"`; on Linux use `xdg-open "<url>"`; otherwise print
+the URL for the user to open manually.
+
+### Step 8: Report
+
+Summarize per pending change (or per logical group of changes) with a
+low/moderate/high risk rating, and call out explicitly:
+
+- Any destructive or backfill-requiring migrations
+- Any schema mirror mismatches
+- Any half-wired or unverified config/secret chains
+- Any new flags that are live-by-default rather than off
+- Any risk category that was skipped because no tooling was available to
+  verify it
+
+Do not silently drop a skipped category from the summary — an unverified
+check is different from a verified-safe one.

--- a/agents/skills/deploy-audit/SKILL.md
+++ b/agents/skills/deploy-audit/SKILL.md
@@ -25,6 +25,9 @@ on its own.
 
 ## Instructions
 
+Work through the following steps in order, gathering enough evidence at each
+one to give the final risk report real teeth rather than a generic checklist.
+
 ### Step 1: Determine the two refs
 
 Parse `$ARGUMENTS` for `<base>..<deployed>`. If only one ref is given, treat it
@@ -32,6 +35,11 @@ as the deployed ref and use the detected default branch as base. If nothing is
 given, look at the remote branches/tags in Context above for likely
 candidates (a `production`/`release`/`deploy` branch, or the most recent tag)
 and ask the user to confirm the base and deployed refs before proceeding.
+
+Refs and the org/repo derived from the remote URL are treated as untrusted
+input for shell purposes: if either contains characters outside
+`[A-Za-z0-9._/-]`, do not interpolate it directly into a shell command —
+quote it and confirm with the user first.
 
 Run `git fetch origin` for both refs to ensure they are current.
 

--- a/agents/skills/deploy-validate/SKILL.md
+++ b/agents/skills/deploy-validate/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: deploy-validate
+description: Validate a deploy after it lands — CI status, rollout health, error tracking, and monitoring/alerting — correlating every finding against the deploy's start time to separate genuine regressions from pre-existing noise. Use when asked to validate a deploy, check post-deploy health, confirm a production rollout is healthy, or after a deploy finishes.
+---
+
+# Post-Deploy Health Validation
+
+Validate that a deploy that has just landed is healthy: confirm it actually
+shipped what was intended, then check CI, rollout, error tracking, and
+monitoring — correlating every finding's timing against the deploy's start so
+pre-existing issues are not mistaken for regressions.
+
+Run this after the user confirms the deploy has finished (this skill does not
+poll or wait for a deploy in progress).
+
+## Arguments
+
+- `$ARGUMENTS` - Optional: the deployed branch/tag/ref, and/or a deploy start
+  timestamp. If omitted, detect the deployed ref the same way `deploy-audit`
+  would and derive the start time from the deploy pipeline itself in Step 2.
+
+## Context
+
+- Remote: !`git remote get-url origin 2>/dev/null | head -1`
+- Default branch: !`git branch -r 2>/dev/null | grep -oE 'origin/(main|master)' | head -1`
+- Current HEAD: !`git rev-parse --short HEAD 2>/dev/null | head -1`
+- Latest tag: !`git describe --tags --abbrev=0 2>/dev/null | head -1`
+
+## Instructions
+
+### Step 1: Confirm the deploy landed
+
+Determine the deployed ref (from `$ARGUMENTS` or by asking, mirroring
+`deploy-audit`'s ref detection). Fetch it and confirm it now points at the
+commit/tag that was intended to ship — e.g. the deployed branch's SHA matches
+the base branch's SHA at the time of the deploy, or a release tag was created
+at the expected commit.
+
+If the deployed ref does not match what was expected, stop and report this
+first — nothing downstream matters if the wrong thing shipped.
+
+### Step 2: Find the deploy pipeline and its start time
+
+Use ToolSearch to find whatever CI/deploy tooling is available in this
+project (search terms like "circleci", "github actions", "pipeline",
+"deploy"). Find the pipeline/workflow run that performed this deploy and
+record:
+
+- Its status (success/failure/in-progress)
+- Its start timestamp — this is the anchor for every correlation in later
+  steps
+
+If no CI tooling is discoverable, ask the user for the deploy start time
+directly rather than guessing.
+
+### Step 3: Check rollout health
+
+Use ToolSearch for whatever deployment/orchestration platform the project
+uses (e.g. terms like "ecs", "kubernetes", "k8s", "cloud run", "deployment").
+For each service touched by the deploy, check:
+
+- Running/healthy instance count matches desired count, with none pending
+- The running image/version tag matches the new release
+
+Query narrowly — one service at a time — rather than enumerating an entire
+cluster in one call; a large cluster's full service list can exceed usable
+output size. If a query risks returning a large amount of data, delegate the
+enumeration to a subagent/fork and have it return only the summary.
+
+### Step 4: Check error tracking, correlated by time
+
+Use ToolSearch for whatever error-tracking tool is available (e.g. terms like
+"sentry", "error tracking", "exception"). Query for issues first seen in a
+window starting shortly before the deploy and continuing to now.
+
+For every issue found, compare its first-seen timestamp against the deploy
+start timestamp from Step 2:
+
+- **First seen before deploy start** → pre-existing noise, not a regression,
+  regardless of how alarming the error looks. Do not report it as caused by
+  this deploy.
+- **First seen at or after deploy start** → candidate regression. Investigate
+  further (stack trace, affected endpoint/service) and include it in the
+  report.
+
+This timestamp correlation is the single most important step in this skill —
+do not substitute keyword matching or severity alone for it.
+
+### Step 5: Check monitoring and alerting, cross-checked against aggregates
+
+Use ToolSearch for whatever monitoring/alerting tool is available (e.g. terms
+like "datadog", "monitor", "alert", "metrics"). Find anything in an alerting
+state for the affected service(s) since the deploy.
+
+Before reporting an alert as a confirmed regression, cross-check it against
+the underlying aggregate metric (e.g. error rate, latency) for the same
+service and time window. A monitor tripping does not always mean a real
+regression — percentile and anomaly-detection monitors can trip on a single
+outlier. Only report it as a likely regression if the aggregate metric itself
+shows a corresponding shift after the deploy start time; otherwise note the
+discrepancy.
+
+### Step 6: Re-verify flagged risks
+
+If a prior `deploy-audit` pass flagged any new feature flags or config risks
+for this deploy, re-check those specific items now that the deploy is live
+(e.g. confirm a flag is still at its intended default). Skip this step if no
+prior audit findings are available.
+
+### Step 7: Report
+
+Summarize:
+
+```
+## Deploy Validation Report
+
+**Deployed ref:** <ref> (matches expected: yes/no)
+**Deploy pipeline:** <status>, started <timestamp>
+
+### Rollout
+<per-service health>
+
+### Error Tracking
+- Pre-existing (filtered out): <count>
+- Candidate regressions (first seen after deploy): <list with detail>
+
+### Monitoring
+- Alerts confirmed against aggregate metrics: <list>
+- Alerts noted but not corroborated by aggregates: <list>
+
+### Flags
+<re-verified risk items, if any>
+
+### Unverified categories
+<any category skipped because no tooling was discoverable>
+
+### Recommendation
+<propose remediation only for genuine, deploy-caused findings; explicitly
+state when the deploy looks healthy>
+```
+
+Do not propose remediation for anything classified as pre-existing noise.

--- a/agents/skills/deploy-validate/SKILL.md
+++ b/agents/skills/deploy-validate/SKILL.md
@@ -28,10 +28,19 @@ poll or wait for a deploy in progress).
 
 ## Instructions
 
+Work through the following steps in order — the timestamp correlation in
+Step 4 is what makes this validation trustworthy rather than a generic
+health-check dashboard.
+
 ### Step 1: Confirm the deploy landed
 
 Determine the deployed ref (from `$ARGUMENTS` or by asking, mirroring
-`deploy-audit`'s ref detection). Fetch it and confirm it now points at the
+`deploy-audit`'s ref detection). Refs are treated as untrusted input for
+shell purposes: if a ref contains characters outside `[A-Za-z0-9._/-]`, do
+not interpolate it directly into a shell command — quote it and confirm with
+the user first.
+
+Fetch it and confirm it now points at the
 commit/tag that was intended to ship — e.g. the deployed branch's SHA matches
 the base branch's SHA at the time of the deploy, or a release tag was created
 at the expected commit.

--- a/openspec/changes/archive/2026-08-15-add-deploy-safety-check-skills/proposal.md
+++ b/openspec/changes/archive/2026-08-15-add-deploy-safety-check-skills/proposal.md
@@ -1,0 +1,29 @@
+# Change: Add deploy-audit and deploy-validate skills
+
+## Why
+
+Deploy safety checks — auditing pending commits before a production deploy and
+validating system health after one lands — are currently done ad hoc, re-derived
+from scratch in conversation every time. The two-phase process (risk audit,
+then post-deploy correlation against deploy timing) is well-defined and
+repeatable but exists nowhere as a reusable skill.
+
+## What Changes
+
+- Add `agents/skills/deploy-audit/SKILL.md`: audits commits pending between a
+  base branch and a deployed branch/tag, assessing migration safety, config
+  wiring completeness, feature-flag defaults, and schema parity, then opens
+  the GitHub compare diff.
+- Add `agents/skills/deploy-validate/SKILL.md`: after a deploy, checks CI
+  status, rollout health, error tracking, and monitoring/alerting, correlating
+  findings against deploy start time to separate genuine regressions from
+  pre-existing noise.
+- Both skills are tool-agnostic: they describe what to check, not which vendor
+  API/MCP tool to call, and instruct Claude to discover whatever tooling
+  (MCP servers or CLIs) is available in the current project.
+
+## Impact
+
+- Affected specs: `deploy-safety` (new capability)
+- Affected code: `agents/skills/deploy-audit/`, `agents/skills/deploy-validate/`,
+  `README.md` (skill table/count)

--- a/openspec/changes/archive/2026-08-15-add-deploy-safety-check-skills/specs/deploy-safety/spec.md
+++ b/openspec/changes/archive/2026-08-15-add-deploy-safety-check-skills/specs/deploy-safety/spec.md
@@ -1,0 +1,91 @@
+## ADDED Requirements
+
+### Requirement: Pre-Deploy Risk Audit Skill
+
+The repository SHALL provide a `deploy-audit` skill that, given a base branch
+(default `master`/`main`) and a deployed branch or tag (default detected from
+common deploy-branch names or asked of the user), enumerates every commit
+pending between them and produces a per-change risk assessment before the
+user opens a PR or ships a deploy.
+
+The audit SHALL cover, for each pending commit or the diff as a whole:
+- Database migration safety (additive vs. destructive, backfill requirements)
+- Schema parity across any mirrored/generated schema copies the project
+  maintains
+- Configuration/secret wiring completeness — for any new environment variable
+  or secret, tracing that it is threaded through every layer of the project's
+  config chain (e.g. IaC variable definitions through to the running
+  task/service config), not just that the secret exists in a vault
+- Feature-flag defaults for any newly introduced flags
+- The full commit log and diff stat between the two refs
+
+The skill SHALL open the GitHub compare diff for the two refs in the browser,
+deriving the org/repo from `git remote get-url origin` rather than a
+hardcoded value.
+
+The skill SHALL be tool-agnostic: it SHALL describe each check as a category
+of risk to investigate, and instruct Claude to use whatever MCP tools, CLIs,
+or file inspection are available in the current project to perform it, rather
+than hardcoding a specific vendor's tool names.
+
+#### Scenario: Auditing pending commits before a deploy
+
+- **WHEN** a user invokes `deploy-audit` in a git repository with a base and
+  deployed branch/tag
+- **THEN** Claude lists every pending commit and file changed between the two
+  refs, assesses migration/config/flag/schema risk, and opens the GitHub
+  compare diff link for the user to review
+
+#### Scenario: No tooling available for a risk category
+
+- **WHEN** a risk category (e.g. feature-flag defaults) has no discoverable
+  MCP tool or CLI in the current project
+- **THEN** the skill SHALL note that category as skipped/unverified rather
+  than silently omitting it from the summary
+
+### Requirement: Post-Deploy Health Validation Skill
+
+The repository SHALL provide a `deploy-validate` skill that, after a deploy
+has landed, checks CI status, deployment/rollout health, error tracking, and
+monitoring/alerting for the deployed service(s), and correlates any findings
+against the deploy's start timestamp to distinguish genuine regressions from
+pre-existing noise.
+
+The skill SHALL:
+- Confirm the deployed ref matches what was intended to ship
+- Check CI/deploy pipeline status for the deploy
+- Check rollout health (e.g. running vs. desired task/instance counts, image
+  version match) for whatever deployment platform the project uses
+- Query error tracking for issues first seen after the deploy's start time,
+  treating anything first seen before that time as pre-existing noise
+- Cross-check any alerting/monitor state against the underlying aggregate
+  metrics for the same service/window before treating an alert as a real
+  regression
+- Re-verify feature-flag defaults for anything flagged as a risk during the
+  corresponding `deploy-audit` pass, if available
+- Be tool-agnostic in the same manner as `deploy-audit`, discovering available
+  MCP tools/CLIs rather than assuming a specific vendor stack
+- Default to narrow, per-service/per-window queries rather than broad
+  enumerations, to avoid unbounded tool output
+
+#### Scenario: Validating a deploy that introduced no regressions
+
+- **WHEN** a user invokes `deploy-validate` after a deploy has finished
+- **THEN** Claude checks CI, rollout, error tracking, and monitoring, and
+  reports the deploy healthy when every discovered issue's first-seen
+  timestamp predates the deploy start
+
+#### Scenario: Distinguishing a real regression from pre-existing noise
+
+- **WHEN** an error-tracking issue's first-seen timestamp is after the
+  deploy's start timestamp
+- **THEN** the skill SHALL flag it as a candidate regression rather than
+  filtering it out as noise
+
+#### Scenario: Monitor alert without a corresponding metric anomaly
+
+- **WHEN** a monitor/alert is in an alerting state but the underlying
+  aggregate metric for the same service/window shows no corresponding
+  anomaly
+- **THEN** the skill SHALL note the discrepancy rather than reporting the
+  alert as a confirmed regression

--- a/openspec/changes/archive/2026-08-15-add-deploy-safety-check-skills/tasks.md
+++ b/openspec/changes/archive/2026-08-15-add-deploy-safety-check-skills/tasks.md
@@ -1,0 +1,23 @@
+## 1. Skills
+
+- [x] 1.1 Write `agents/skills/deploy-audit/SKILL.md`
+- [x] 1.2 Write `agents/skills/deploy-validate/SKILL.md`
+
+## 2. Docs
+
+- [x] 2.1 Update `README.md` skill table and count
+
+## 3. Validation
+
+- [x] 3.1 `go install ./...`
+- [x] 3.2 `revive -set_exit_status ./...`
+- [x] 3.3 `go test ./...`
+- [x] 3.4 `bash .github/skill-tests/run_all.sh`
+- [x] 3.5 `bash .github/lint-skills.sh`
+- [x] 3.6 `qlty check --all --no-fix --level=high`
+- [x] 3.7 `qlty smells --all --no-snippets`
+
+## 4. Archive
+
+- [x] 4.1 `openspec archive add-deploy-safety-check-skills --skip-specs --yes` (base spec created by hand — see commit)
+- [x] 4.2 `openspec validate --strict`

--- a/openspec/specs/deploy-safety/spec.md
+++ b/openspec/specs/deploy-safety/spec.md
@@ -1,0 +1,101 @@
+# deploy-safety Specification
+
+## Purpose
+
+The `deploy-safety` capability defines two reusable skills for auditing deploy
+risk before a production deploy ships and validating system health after it
+lands: `deploy-audit` and `deploy-validate`. Both are tool-agnostic — they
+describe what to check, and rely on Claude discovering whatever MCP
+tools/CLIs are available in the current project to perform each check.
+
+## Requirements
+
+### Requirement: Pre-Deploy Risk Audit Skill
+
+The repository SHALL provide a `deploy-audit` skill that, given a base branch
+(default `master`/`main`) and a deployed branch or tag (default detected from
+common deploy-branch names or asked of the user), enumerates every commit
+pending between them and produces a per-change risk assessment before the
+user opens a PR or ships a deploy.
+
+The audit SHALL cover, for each pending commit or the diff as a whole:
+- Database migration safety (additive vs. destructive, backfill requirements)
+- Schema parity across any mirrored/generated schema copies the project
+  maintains
+- Configuration/secret wiring completeness — for any new environment variable
+  or secret, tracing that it is threaded through every layer of the project's
+  config chain (e.g. IaC variable definitions through to the running
+  task/service config), not just that the secret exists in a vault
+- Feature-flag defaults for any newly introduced flags
+- The full commit log and diff stat between the two refs
+
+The skill SHALL open the GitHub compare diff for the two refs in the browser,
+deriving the org/repo from `git remote get-url origin` rather than a
+hardcoded value.
+
+The skill SHALL be tool-agnostic: it SHALL describe each check as a category
+of risk to investigate, and instruct Claude to use whatever MCP tools, CLIs,
+or file inspection are available in the current project to perform it, rather
+than hardcoding a specific vendor's tool names.
+
+#### Scenario: Auditing pending commits before a deploy
+
+- **WHEN** a user invokes `deploy-audit` in a git repository with a base and
+  deployed branch/tag
+- **THEN** Claude lists every pending commit and file changed between the two
+  refs, assesses migration/config/flag/schema risk, and opens the GitHub
+  compare diff link for the user to review
+
+#### Scenario: No tooling available for a risk category
+
+- **WHEN** a risk category (e.g. feature-flag defaults) has no discoverable
+  MCP tool or CLI in the current project
+- **THEN** the skill SHALL note that category as skipped/unverified rather
+  than silently omitting it from the summary
+
+### Requirement: Post-Deploy Health Validation Skill
+
+The repository SHALL provide a `deploy-validate` skill that, after a deploy
+has landed, checks CI status, deployment/rollout health, error tracking, and
+monitoring/alerting for the deployed service(s), and correlates any findings
+against the deploy's start timestamp to distinguish genuine regressions from
+pre-existing noise.
+
+The skill SHALL:
+- Confirm the deployed ref matches what was intended to ship
+- Check CI/deploy pipeline status for the deploy
+- Check rollout health (e.g. running vs. desired task/instance counts, image
+  version match) for whatever deployment platform the project uses
+- Query error tracking for issues first seen after the deploy's start time,
+  treating anything first seen before that time as pre-existing noise
+- Cross-check any alerting/monitor state against the underlying aggregate
+  metrics for the same service/window before treating an alert as a real
+  regression
+- Re-verify feature-flag defaults for anything flagged as a risk during the
+  corresponding `deploy-audit` pass, if available
+- Be tool-agnostic in the same manner as `deploy-audit`, discovering available
+  MCP tools/CLIs rather than assuming a specific vendor stack
+- Default to narrow, per-service/per-window queries rather than broad
+  enumerations, to avoid unbounded tool output
+
+#### Scenario: Validating a deploy that introduced no regressions
+
+- **WHEN** a user invokes `deploy-validate` after a deploy has finished
+- **THEN** Claude checks CI, rollout, error tracking, and monitoring, and
+  reports the deploy healthy when every discovered issue's first-seen
+  timestamp predates the deploy start
+
+#### Scenario: Distinguishing a real regression from pre-existing noise
+
+- **WHEN** an error-tracking issue's first-seen timestamp is after the
+  deploy's start timestamp
+- **THEN** the skill SHALL flag it as a candidate regression rather than
+  filtering it out as noise
+
+#### Scenario: Monitor alert without a corresponding metric anomaly
+
+- **WHEN** a monitor/alert is in an alerting state but the underlying
+  aggregate metric for the same service/window shows no corresponding
+  anomaly
+- **THEN** the skill SHALL note the discrepancy rather than reporting the
+  alert as a confirmed regression


### PR DESCRIPTION
Encodes the two-phase deploy-safety workflow (pre-deploy risk audit of pending commits, post-deploy health validation correlated against deploy timing) as reusable, tool-agnostic skills instead of re-deriving it ad hoc every deploy. Adds the deploy-safety OpenSpec capability, wires both skills into the Codex/Copilot routing table, and updates the README skill table/count.

Co-Authored-By: Claude <noreply@anthropic.com>