### PR TITLE
Fix nil crash in Hammerspoon music display()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,8 @@ qlty smells --all --no-snippets               # Maintainability scan (same as CI
 
 Do not skip any of these steps. If any command fails, fix the issue before finishing. This applies to all tasks — feature work, bug fixes, skill changes, and documentation updates.
 
+If `go install`/`go test`/`go vet` fails with `failed to initialize build cache ... mkdir ... operation not permitted` under a sandboxed agent, redirect the build cache: `export GOCACHE=/tmp/gocache-<worktree>` before running the Go commands. The Claude Code sandbox can block writes to the default `~/.argus/cache/go-build`, the same class of issue as the `qlty` `HOME` workaround above.
+
 ## Critical Notes
 
 - Installation is destructive (no backups)

--- a/hammerspoon/lib.lua
+++ b/hammerspoon/lib.lua
@@ -9,6 +9,13 @@ function lib.formatSeconds(seconds)
   return formatted
 end
 
+function lib.percentComplete(current, total)
+  current = current or 0
+  total = total or 0
+  if total == 0 then return 0 end
+  return math.floor(current / total * 100 + 0.5)
+end
+
 function lib.frameForUnit(baseframe, unit)
   return {
     x = baseframe.x + (unit.x * baseframe.w),

--- a/hammerspoon/lib.lua
+++ b/hammerspoon/lib.lua
@@ -13,7 +13,10 @@ function lib.percentComplete(current, total)
   current = current or 0
   total = total or 0
   if total == 0 then return 0 end
-  return math.floor(current / total * 100 + 0.5)
+  local percent = math.floor(current / total * 100 + 0.5)
+  if percent < 0 then return 0 end
+  if percent > 100 then return 100 end
+  return percent
 end
 
 function lib.frameForUnit(baseframe, unit)

--- a/hammerspoon/music/apple_music.lua
+++ b/hammerspoon/music/apple_music.lua
@@ -4,7 +4,8 @@ local as    = require 'hs.applescript'
 local alert = require 'alert'
 local lib   = require 'lib'
 
-local formatSeconds = lib.formatSeconds
+local formatSeconds   = lib.formatSeconds
+local percentComplete = lib.percentComplete
 
 local function tell(cmd)
   local _cmd = 'tell application "Music" to ' .. cmd
@@ -102,9 +103,9 @@ function itunes.display()
   local artist = hs.itunes.getCurrentArtist() or ''
   local album  = hs.itunes.getCurrentAlbum() or ''
   local track  = hs.itunes.getCurrentTrack() or ''
-  local current = hs.itunes.getPosition()
+  local current = hs.itunes.getPosition() or 0
   local total   = duration()
-  local percent = math.floor(current / total * 100 + 0.5)
+  local percent = percentComplete(current, total)
   local time   = (
     formatSeconds(current)..
     '  ('..percent..'%)'..

--- a/hammerspoon/music/spotify.lua
+++ b/hammerspoon/music/spotify.lua
@@ -3,7 +3,8 @@ local alert = require 'alert'
 local as    = require 'hs.applescript'
 local lib   = require 'lib'
 
-local formatSeconds = lib.formatSeconds
+local formatSeconds   = lib.formatSeconds
+local percentComplete = lib.percentComplete
 
 local function tell(cmd)
   local _cmd = 'tell application "Spotify" to ' .. cmd
@@ -100,9 +101,9 @@ function spotify.display()
   local artist = hs.spotify.getCurrentArtist() or ''
   local album  = hs.spotify.getCurrentAlbum() or ''
   local track  = hs.spotify.getCurrentTrack() or ''
-  local current = hs.spotify.getPosition()
+  local current = hs.spotify.getPosition() or 0
   local total   = duration()
-  local percent = math.floor(current / total * 100 + 0.5)
+  local percent = percentComplete(current, total)
   local time   = (
     formatSeconds(current)..
     '  ('..percent..'%)'..

--- a/hammerspoon/test.lua
+++ b/hammerspoon/test.lua
@@ -54,6 +54,9 @@ eq('nil current',     lib.percentComplete(nil, 100),  0)
 eq('nil total',       lib.percentComplete(50, nil),   0)
 eq('nil current+total', lib.percentComplete(nil, nil), 0)
 eq('zero total',      lib.percentComplete(50, 0),     0)
+eq('half rounds up',  lib.percentComplete(1, 8),      13)
+eq('over total clamps', lib.percentComplete(105, 100), 100)
+eq('negative clamps', lib.percentComplete(-10, 100),  0)
 
 -- frameForUnit
 

--- a/hammerspoon/test.lua
+++ b/hammerspoon/test.lua
@@ -45,6 +45,16 @@ eq('1h 1m 1s',          lib.formatSeconds(3661),  '1h 1m 1s')
 eq('2h 30m 45s',        lib.formatSeconds(9045),  '2h 30m 45s')
 eq('fractional floors', lib.formatSeconds(90.7),  '1m 30s')
 
+-- percentComplete
+
+eq('50 of 100',       lib.percentComplete(50, 100),   50)
+eq('0 of 100',        lib.percentComplete(0, 100),    0)
+eq('rounds up',       lib.percentComplete(67, 100),   67)
+eq('nil current',     lib.percentComplete(nil, 100),  0)
+eq('nil total',       lib.percentComplete(50, nil),   0)
+eq('nil current+total', lib.percentComplete(nil, nil), 0)
+eq('zero total',      lib.percentComplete(50, 0),     0)
+
 -- frameForUnit
 
 local screen = { x=0, y=0, w=1920, h=1080 }


### PR DESCRIPTION
hs.itunes.getPosition()/hs.spotify.getPosition() can return nil when no playback position is available, crashing display() on arithmetic with nil. Extracts the percent-of-track math into a nil- and zero-total-safe lib.percentComplete, clamped to 0-100, with unit tests covering the nil/zero/rounding/out-of-range cases. Also documents a GOCACHE sandbox workaround for go install/test in the Pre-Completion Checklist.

Co-Authored-By: Claude <noreply@anthropic.com>