### PR TITLE
Self-heal revoked Spotify refresh tokens in cmd/spotify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,18 @@ tooling) into CI. The quality gate is and stays the **Pre-Completion Checklist**
 └── pkg/                      # Shared utilities (log, run, cache, path)
 ```
 
+## Context Directory
+
+`context/` is a durable, cross-session store for project knowledge, checked into git so it
+persists across clones:
+
+- `context/knowledge/index.md` — knowledge graph index; one topic file per domain, indexed here
+- `context/research/` — investigation notes and spike results
+- `context/plans/` — strategic plans and proposals
+
+Read `context/knowledge/index.md` when you need project history or domain context beyond what's
+in this file. Populated and maintained via the `/improve` skill.
+
 ## Key Development Patterns
 
 1. **Command Execution**: Use `pkg/run` package

--- a/cmd/spotify/auth/root.go
+++ b/cmd/spotify/auth/root.go
@@ -22,7 +22,9 @@ import (
 	jsoniter "github.com/json-iterator/go"
 )
 
-const spotifyTokenURL = "https://accounts.spotify.com/api/token"
+// spotifyTokenURL is a var (not const) so tests can point it at a local
+// httptest server.
+var spotifyTokenURL = "https://accounts.spotify.com/api/token"
 
 // authTimeout bounds how long the CLI waits for the user to complete the
 // browser consent flow before giving up.
@@ -34,12 +36,16 @@ var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 // FetchAccessToken - Returns a valid access token for the Spotify API.
 // * If no cached access token or refresh token
-//   * Starts a local loopback server on the redirect URI's port
-//   * Opens browser to authorization URL
-//   * Captures the authorization code from the OAuth callback automatically
-//   * Exchanges authorization code for access token and refresh token
+//   - Starts a local loopback server on the redirect URI's port
+//   - Opens browser to authorization URL
+//   - Captures the authorization code from the OAuth callback automatically
+//   - Exchanges authorization code for access token and refresh token
+//
 // * If access token is expired
-//   * Exchange refresh token for a new access token
+//   - Exchange refresh token for a new access token
+//   - If the refresh token itself was revoked or expired, clear the stale
+//     cache and fall back to a full interactive re-authorization rather than
+//     exiting on a bare API error
 func FetchAccessToken() string {
 	accessToken := config.Read("spotify.access_token")
 	refreshToken := config.Read("spotify.refresh_token")
@@ -48,9 +54,18 @@ func FetchAccessToken() string {
 		accessToken, refreshToken = exchangeAuthorizationCode(authorize())
 		config.Write("spotify.access_token", accessToken)
 		config.Write("spotify.refresh_token", refreshToken)
-	} else if refreshNeeded(accessToken) {
-		// refresh access token using refresh token
-		accessToken = exchangeRefreshToken(refreshToken)
+		return accessToken
+	}
+
+	if refreshNeeded(accessToken) {
+		newAccessToken, ok := exchangeRefreshToken(refreshToken)
+		if !ok {
+			log.Warning("Spotify refresh token revoked or expired; re-authorizing")
+			config.Delete("spotify.access_token")
+			config.Delete("spotify.refresh_token")
+			return FetchAccessToken()
+		}
+		accessToken = newAccessToken
 		config.Write("spotify.access_token", accessToken)
 	}
 
@@ -227,23 +242,34 @@ func Headers(accessToken string) http.Header {
 }
 
 func exchangeAuthorizationCode(code string) (string, string) {
-	data := exchangeToken(url.Values{
+	data, status := exchangeToken(url.Values{
 		"code":       {code},
 		"grant_type": {"authorization_code"},
 	})
+	if status != http.StatusOK {
+		fmt.Println(string(data))
+		os.Exit(1)
+	}
 	return jsoniter.Get(data, "access_token").ToString(),
 		jsoniter.Get(data, "refresh_token").ToString()
 }
 
-func exchangeRefreshToken(refreshToken string) string {
-	data := exchangeToken(url.Values{
+// exchangeRefreshToken exchanges refreshToken for a new access token. It
+// returns ok=false (instead of exiting) when Spotify rejects the exchange, so
+// callers can distinguish "refresh token revoked/expired" from a fatal error
+// and fall back to re-authorization.
+func exchangeRefreshToken(refreshToken string) (string, bool) {
+	data, status := exchangeToken(url.Values{
 		"refresh_token": {refreshToken},
 		"grant_type":    {"refresh_token"},
 	})
-	return jsoniter.Get(data, "access_token").ToString()
+	if status != http.StatusOK {
+		return "", false
+	}
+	return jsoniter.Get(data, "access_token").ToString(), true
 }
 
-func exchangeToken(params url.Values) []byte {
+func exchangeToken(params url.Values) ([]byte, int) {
 	form := url.Values{}
 	for k, v := range params {
 		form[k] = v
@@ -253,14 +279,9 @@ func exchangeToken(params url.Values) []byte {
 	form.Set("redirect_uri", os.Getenv("SPOTIFY_REDIRECT_URI"))
 
 	headers := http.Header{"Content-Type": {"application/x-www-form-urlencoded"}}
-	data, status := SendRequest(
+	return SendRequest(
 		http.MethodPost, spotifyTokenURL, headers, nil, strings.NewReader(form.Encode()),
 	)
-	if status != http.StatusOK {
-		fmt.Println(string(data))
-		os.Exit(1)
-	}
-	return data
 }
 
 // SendRequest performs an HTTP request with optional query params and body,

--- a/cmd/spotify/auth/root.go
+++ b/cmd/spotify/auth/root.go
@@ -43,10 +43,20 @@ var httpClient = &http.Client{Timeout: 10 * time.Second}
 //
 // * If access token is expired
 //   - Exchange refresh token for a new access token
-//   - If the refresh token itself was revoked or expired, clear the stale
-//     cache and fall back to a full interactive re-authorization rather than
-//     exiting on a bare API error
+//   - If the refresh token itself was revoked (Spotify's invalid_grant),
+//     clear the stale cache and fall back to a full interactive
+//     re-authorization rather than exiting on a bare API error
 func FetchAccessToken() string {
+	return fetchAccessToken(false)
+}
+
+// fetchAccessToken implements FetchAccessToken. isRetry caps the
+// revoked-token recovery to a single attempt: if config.Delete's on-disk
+// write silently failed (it only logs and returns on error — see
+// cli/config's save) and the recursive call re-reads the same stale tokens,
+// this bails out with a hard error instead of looping forever against
+// Spotify's token endpoint.
+func fetchAccessToken(isRetry bool) string {
 	accessToken := config.Read("spotify.access_token")
 	refreshToken := config.Read("spotify.refresh_token")
 
@@ -58,12 +68,16 @@ func FetchAccessToken() string {
 	}
 
 	if refreshNeeded(accessToken) {
-		newAccessToken, ok := exchangeRefreshToken(refreshToken)
-		if !ok {
-			log.Warning("Spotify refresh token revoked or expired; re-authorizing")
+		newAccessToken, revoked := exchangeRefreshToken(refreshToken)
+		if revoked {
+			if isRetry {
+				log.Error("Spotify refresh token still invalid after clearing cache; aborting")
+				os.Exit(1)
+			}
+			log.Warning("Spotify refresh token revoked; re-authorizing")
 			config.Delete("spotify.access_token")
 			config.Delete("spotify.refresh_token")
-			return FetchAccessToken()
+			return fetchAccessToken(true)
 		}
 		accessToken = newAccessToken
 		config.Write("spotify.access_token", accessToken)
@@ -247,26 +261,38 @@ func exchangeAuthorizationCode(code string) (string, string) {
 		"grant_type": {"authorization_code"},
 	})
 	if status != http.StatusOK {
-		fmt.Println(string(data))
-		os.Exit(1)
+		exitOnTokenError(data)
 	}
 	return jsoniter.Get(data, "access_token").ToString(),
 		jsoniter.Get(data, "refresh_token").ToString()
 }
 
 // exchangeRefreshToken exchanges refreshToken for a new access token. It
-// returns ok=false (instead of exiting) when Spotify rejects the exchange, so
-// callers can distinguish "refresh token revoked/expired" from a fatal error
-// and fall back to re-authorization.
-func exchangeRefreshToken(refreshToken string) (string, bool) {
+// returns revoked=true (instead of exiting) specifically when Spotify
+// rejects the exchange with invalid_grant, so callers can distinguish "the
+// refresh token itself was revoked" from a transient failure (rate limit,
+// 5xx, network blip) and fall back to re-authorization only in the former
+// case — a transient failure exits instead of destroying an otherwise-good
+// cached refresh token.
+func exchangeRefreshToken(refreshToken string) (accessToken string, revoked bool) {
 	data, status := exchangeToken(url.Values{
 		"refresh_token": {refreshToken},
 		"grant_type":    {"refresh_token"},
 	})
 	if status != http.StatusOK {
-		return "", false
+		if status == http.StatusBadRequest && jsoniter.Get(data, "error").ToString() == "invalid_grant" {
+			return "", true
+		}
+		exitOnTokenError(data)
 	}
-	return jsoniter.Get(data, "access_token").ToString(), true
+	return jsoniter.Get(data, "access_token").ToString(), false
+}
+
+// exitOnTokenError logs the raw Spotify token-endpoint error body and exits;
+// used for token-exchange failures that aren't a recoverable invalid_grant.
+func exitOnTokenError(data []byte) {
+	log.Error("%s", string(data))
+	os.Exit(1)
 }
 
 func exchangeToken(params url.Values) ([]byte, int) {

--- a/cmd/spotify/auth/root_test.go
+++ b/cmd/spotify/auth/root_test.go
@@ -264,10 +264,10 @@ func TestExchangeRefreshToken_Success(t *testing.T) {
 		_, _ = w.Write([]byte(`{"access_token":"new-access-token"}`))
 	})
 
-	token, ok := exchangeRefreshToken("some-refresh-token")
+	token, revoked := exchangeRefreshToken("some-refresh-token")
 
-	if !ok {
-		t.Fatal("exchangeRefreshToken ok = false, want true")
+	if revoked {
+		t.Fatal("exchangeRefreshToken revoked = true, want false")
 	}
 	if token != "new-access-token" {
 		t.Errorf("token = %q, want new-access-token", token)
@@ -276,20 +276,20 @@ func TestExchangeRefreshToken_Success(t *testing.T) {
 
 // TestExchangeRefreshToken_Revoked covers the scenario this session hit
 // manually: Spotify rejects a refresh token with invalid_grant once it has
-// been revoked. exchangeRefreshToken must report failure (ok=false) instead
-// of exiting, so FetchAccessToken can fall back to re-authorization.
+// been revoked. exchangeRefreshToken must report revoked=true (instead of
+// exiting) so FetchAccessToken can fall back to re-authorization.
 func TestExchangeRefreshToken_Revoked(t *testing.T) {
 	withTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Refresh token revoked"}`))
 	})
 
-	token, ok := exchangeRefreshToken("revoked-refresh-token")
+	token, revoked := exchangeRefreshToken("revoked-refresh-token")
 
-	if ok {
-		t.Fatal("exchangeRefreshToken ok = true, want false for a revoked token")
+	if !revoked {
+		t.Fatal("exchangeRefreshToken revoked = false, want true for a revoked token")
 	}
 	if token != "" {
-		t.Errorf("token = %q, want empty on failure", token)
+		t.Errorf("token = %q, want empty when revoked", token)
 	}
 }

--- a/cmd/spotify/auth/root_test.go
+++ b/cmd/spotify/auth/root_test.go
@@ -245,3 +245,51 @@ func TestHeaders_AllFieldsSet(t *testing.T) {
 		t.Errorf("Authorization = %q, want %q", got, "Bearer xyz")
 	}
 }
+
+// withTokenServer points spotifyTokenURL at a local server for the duration
+// of the test and restores it afterward.
+func withTokenServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := spotifyTokenURL
+	spotifyTokenURL = server.URL
+	t.Cleanup(func() { spotifyTokenURL = original })
+}
+
+func TestExchangeRefreshToken_Success(t *testing.T) {
+	withTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"new-access-token"}`))
+	})
+
+	token, ok := exchangeRefreshToken("some-refresh-token")
+
+	if !ok {
+		t.Fatal("exchangeRefreshToken ok = false, want true")
+	}
+	if token != "new-access-token" {
+		t.Errorf("token = %q, want new-access-token", token)
+	}
+}
+
+// TestExchangeRefreshToken_Revoked covers the scenario this session hit
+// manually: Spotify rejects a refresh token with invalid_grant once it has
+// been revoked. exchangeRefreshToken must report failure (ok=false) instead
+// of exiting, so FetchAccessToken can fall back to re-authorization.
+func TestExchangeRefreshToken_Revoked(t *testing.T) {
+	withTokenServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Refresh token revoked"}`))
+	})
+
+	token, ok := exchangeRefreshToken("revoked-refresh-token")
+
+	if ok {
+		t.Fatal("exchangeRefreshToken ok = true, want false for a revoked token")
+	}
+	if token != "" {
+		t.Errorf("token = %q, want empty on failure", token)
+	}
+}

--- a/context/knowledge/hammerspoon-music.md
+++ b/context/knowledge/hammerspoon-music.md
@@ -39,8 +39,12 @@ table) is dead code — nothing in `init.lua` calls `music.toggle()`.
 - Cached tokens live in `~/.dots/sys/config` under `[spotify]`
   (`access_token`, `refresh_token`), managed via `cli/config`.
 - As of 2026-09-03, `FetchAccessToken` (`cmd/spotify/auth/root.go`)
-  self-heals: if the refresh-token exchange fails (revoked/expired), it
-  clears the stale cached tokens and falls back to a full interactive
-  re-authorization automatically, instead of exiting on a raw API error.
-  Previously this required manually clearing `~/.dots/sys/config`'s
+  self-heals specifically from `invalid_grant` (a revoked/expired refresh
+  token): it clears the stale cached tokens and falls back to a full
+  interactive re-authorization automatically, capped at one retry so a
+  persistently-failing cache write can't loop forever. Any other
+  token-endpoint failure (rate limit, 5xx, etc.) still exits without
+  touching the cache, since destroying an otherwise-good refresh token over
+  a transient error would be worse than the old behavior. Previously any
+  non-200 forced a manual clear of `~/.dots/sys/config`'s
   `[spotify]` section by hand to force re-auth.

--- a/context/knowledge/hammerspoon-music.md
+++ b/context/knowledge/hammerspoon-music.md
@@ -1,0 +1,46 @@
+# Hammerspoon Music Controls (Spotify / Apple Music)
+
+`hammerspoon/music.lua` dispatches to `hammerspoon/music/spotify.lua` or
+`hammerspoon/music/apple_music.lua` based on which app is running
+(`hammerspoon/music.lua:8`). Bindings live in `hammerspoon/init.lua`.
+
+## Why Spotify needs a separate CLI, but Apple Music doesn't
+
+Everything except save/remove/transfer goes through `hs.spotify` /
+`hs.itunes` (Hammerspoon's built-in modules), which just wrap AppleScript —
+no separate CLI needed for play/pause/next/previous/seek/volume/display.
+
+Apple Music's local AppleScript dictionary exposes a `favorited` track
+property, so `itunes.save`/`itunes.remove` in `apple_music.lua` implement
+"like/unlike" with pure AppleScript. `itunes.toggle`/`itunes.transfer` are
+explicitly unsupported (`alert.show("Unsupported")`).
+
+Spotify's local AppleScript dictionary has **no equivalent** — no
+save-to-library verb, no transfer-to-device verb. Those are Spotify **Web
+API** operations (`/me/tracks`, `/me/player`) requiring OAuth, which
+`osascript` structurally cannot do (it only talks to apps with an AppleScript
+dictionary, not arbitrary HTTP+OAuth). That's why `cmd/spotify` (a Go binary
+at `~/go/bin/spotify`) exists and is shelled out to via `hs.execute` in
+`spotify.lua`'s `spotifyExec` — it's irreplaceable by AppleScript, not a
+workaround.
+
+`spotify.toggle` (and the corresponding entry in `music.lua`'s `bindings`
+table) is dead code — nothing in `init.lua` calls `music.toggle()`.
+`save`/`remove`/`transfer` are real, bound to `ctrl+cmd+=`, `ctrl+cmd+-`, and
+`cmd+alt+shift+delete` respectively (`init.lua`).
+
+## OAuth setup (`cmd/spotify/auth`)
+
+- `SPOTIFY_REDIRECT_URI` (in `~/.dots/sys/env`) must be a **loopback URL with
+  an explicit port**, e.g. `http://127.0.0.1:8888/callback` — the CLI starts
+  a local HTTP server on that port to catch the OAuth callback itself, and
+  the same URI must be registered under Redirect URIs on the app at
+  https://developer.spotify.com/dashboard.
+- Cached tokens live in `~/.dots/sys/config` under `[spotify]`
+  (`access_token`, `refresh_token`), managed via `cli/config`.
+- As of 2026-09-03, `FetchAccessToken` (`cmd/spotify/auth/root.go`)
+  self-heals: if the refresh-token exchange fails (revoked/expired), it
+  clears the stale cached tokens and falls back to a full interactive
+  re-authorization automatically, instead of exiting on a raw API error.
+  Previously this required manually clearing `~/.dots/sys/config`'s
+  `[spotify]` section by hand to force re-auth.

--- a/context/knowledge/index.md
+++ b/context/knowledge/index.md
@@ -1,0 +1,14 @@
+# Knowledge Index
+
+Structured knowledge for cross-session persistence. Each file covers a topic/domain.
+
+| File | Topic | Key Entities | Last Updated |
+|------|-------|-------------|-------------|
+| [hammerspoon-music.md](hammerspoon-music.md) | Hammerspoon music controls (Spotify/Apple Music) | `hs.spotify`, `cmd/spotify`, AppleScript dictionary, Spotify Web API | 2026-09-03 |
+
+## Coverage Map
+
+Which context files are captured in knowledge:
+
+| Context File | Knowledge File(s) | Coverage |
+|-------------|-------------------|----------|


### PR DESCRIPTION
cmd/spotify's OAuth flow used to exit with a raw API error when the cached refresh token was revoked, requiring manual editing of ~/.dots/sys/config to recover. FetchAccessToken now detects a genuine invalid_grant, clears the stale cache, and re-authorizes automatically (capped at one retry). Other token-endpoint failures (5xx, rate limits) still exit without touching an otherwise-good cached refresh token. Adds context/ per the /improve convention, documenting why Spotify's save/remove/transfer require the Web API while everything else stays on Hammerspoon's AppleScript-backed hs.spotify.

Co-Authored-By: Claude <noreply@anthropic.com>