### PR TITLE
Add notion-address-comments skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ dots docker stop-all     # Stop all Docker containers
 
 ## Agent Skills
 
-Dots includes 71 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
+Dots includes 72 reusable slash-command skills for AI coding agents, following the [Agent Skills](https://agentskills.io) open standard. Each skill lives in `agents/skills/<name>/SKILL.md` and is available as `/<name>` in Claude Code after running `dots install agents`.
 
 | Skill | Description |
 |-------|-------------|
@@ -195,7 +195,7 @@ Run `dots install agents` to symlink them to `~/.claude/agents/`.
 ├── pi/                        # pi.dev coding agent config (models.json only)
 │
 ├── agents/                    # Agent configuration
-│   ├── skills/                # 71 reusable skills (SKILL.md per skill)
+│   ├── skills/                # 72 reusable skills (SKILL.md per skill)
 │   └── custom/                # 3 custom agent types (.md per agent)
 │       └── tests/             # Skill test suite
 │

--- a/agents/skills/deploy-audit/SKILL.md
+++ b/agents/skills/deploy-audit/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deploy-audit
 description: Audit every commit pending between a base branch and a deployed branch/tag for deploy risk (migrations, config/secret wiring completeness, feature-flag defaults, schema parity), then open the GitHub compare diff. Use when asked to audit pending commits, check deploy risk, review what is about to ship, or before opening a deploy PR or shipping to production.
+disable-model-invocation: true
 ---
 
 # Pre-Deploy Risk Audit

--- a/agents/skills/deploy-validate/SKILL.md
+++ b/agents/skills/deploy-validate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deploy-validate
 description: Validate a deploy after it lands — CI status, rollout health, error tracking, and monitoring/alerting — correlating every finding against the deploy's start time to separate genuine regressions from pre-existing noise. Use when asked to validate a deploy, check post-deploy health, confirm a production rollout is healthy, or after a deploy finishes.
+disable-model-invocation: true
 ---
 
 # Post-Deploy Health Validation

--- a/agents/skills/notion-address-comments/SKILL.md
+++ b/agents/skills/notion-address-comments/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: notion-address-comments
+description: Iterate on a Notion page against its open inline comments — read each unresolved thread, edit the page to address it, and reply with a short summary of the change. Use when the user asks to address the comments in a Notion doc, address feedback left as inline Notion comments, or is running an iterative doc-drafting session where Notion comments are the direction.
+---
+
+# Notion Address Comments (Read-Write)
+
+Iterate on a Notion page against its open inline comment threads via MCP tools. This
+skill covers writing to a page and replying to comment threads — the sibling `notion`
+skill is read-only. See `agents/skills/notion/SKILL.md` for plain page reads.
+
+## Arguments
+
+- `$ARGUMENTS` — The Notion page URL or page ID to iterate on.
+
+## Quick Reference: MCP Tools
+
+| Tool | Use For |
+|------|---------|
+| `mcp__claude_ai_Notion__notion-get-comments` | List comment threads on a page (resolved threads excluded by default) |
+| `mcp__claude_ai_Notion__notion-fetch` | Read the page's current content as Notion-flavored markdown |
+| `mcp__claude_ai_Notion__notion-update-page` | Edit page content (`command: update_content`) |
+| `mcp__claude_ai_Notion__notion-create-comment` | Reply into a comment thread (`discussion_id`) |
+
+If these tools are not available, search for an equivalent Notion write-capable MCP
+server before falling back to asking the user to make the edit manually — this skill
+has no read-only fallback path since the whole point is writing.
+
+## Your task
+
+Given a Notion page with open inline comments, address every unresolved thread: edit
+the page to do what the thread asks, then reply summarizing the change. End with a
+one-line tally and an explicit note that addressed threads remain open for the user to
+resolve manually — there is no resolve-thread tool in this toolset.
+
+Do not re-enter this workflow for threads already answered on a prior pass unless a
+newer comment has been posted on them since your last reply.
+
+### Step 1: List open comment threads
+
+Call `mcp__claude_ai_Notion__notion-get-comments` with the page ID and
+`include_all_blocks: true`. Resolved threads are excluded automatically, so every
+thread returned is a candidate for action.
+
+For each thread, check whether the last comment is already from this skill (compare
+comment authorship/timestamps against any prior reply). If so, and no newer comment
+exists after it, skip the thread entirely — it was already addressed on a previous
+pass. If there is no open thread at all, stop and report: `No open comment threads on
+this page.`
+
+### Step 2: Re-fetch the page before each edit
+
+Immediately before building an edit for a thread, call
+`mcp__claude_ai_Notion__notion-fetch` on the page ID to get its current content. Do not
+reuse content fetched earlier in the session or from a prior turn — a prior edit
+(including one the user made manually between turns) shifts surrounding text, and a
+stale copy produces a failed text match when the edit is applied.
+
+### Step 3: Build and apply the edit
+
+Construct an old-text/new-text pair for `mcp__claude_ai_Notion__notion-update-page`
+with `command: update_content`, matching the fetched content exactly.
+
+Watch for one specific gotcha: bold markdown inside a commented sentence splits that
+sentence into multiple adjacent span tags carrying a discussion-urls attribute, one
+span per segment around each bold marker. Match every one of those spans exactly as
+they appear in the fetch output rather than assuming the whole sentence is a single
+span. Preserve the span wrapper(s) around the edited text so the comment stays
+anchored to it — only drop a wrapper when the text it anchors is being removed
+entirely.
+
+Keep the edit scoped to what the thread is asking for. If multiple open threads point
+at the same passage, resolve them together in one edit rather than applying conflicting
+changes one after another.
+
+### Step 4: Reply to the thread
+
+Call `mcp__claude_ai_Notion__notion-create-comment` with the thread's `discussion_id`
+and a short reply describing what changed, for example: `Updated — <one line on the
+change>.` Post the reply after the edit succeeds, so the reply always describes what
+is actually on the page.
+
+### Step 5: Report
+
+After every open thread is processed, print a tight summary:
+
+```
+Page: <url>
+Addressed N of M open threads.
+<one line per addressed thread, referencing what changed>
+No resolve-thread tool available — threads remain open for you to resolve manually in Notion.
+```
+
+If a thread could not be addressed (the request was unclear, or the edit could not be
+matched against current content after a retry), say so explicitly in the summary rather
+than silently skipping it.
+
+## Notes and edge cases
+
+- **Comment IDs and idempotency.** Track which threads already have a reply from this
+  skill. A thread only warrants another pass when a comment newer than that reply has
+  been added — otherwise leave it alone.
+- **No resolve tool.** This toolset has no way to mark a thread resolved. Never imply in
+  a reply or summary that a thread was closed — state plainly that resolution is a
+  manual step for the user.
+- **Failed text match.** If an edit's old-text does not match after a fresh fetch, do
+  not guess at a fuzzy replacement — re-read the fetched content around the comment's
+  anchor and rebuild the old-text exactly, retrying once before reporting the thread as
+  blocked.

--- a/agents/skills/notion/SKILL.md
+++ b/agents/skills/notion/SKILL.md
@@ -77,5 +77,6 @@ Notion pages can return very large responses (100K+ characters) that exceed toke
 
 ## Limitations
 
-- **Read-only** — Cannot create, update, or delete pages
+- **Read-only** — Cannot create, update, or delete pages. For editing a page and
+  replying to inline comment threads, use the `notion-address-comments` skill instead.
 - Page content is returned as Notion-flavored markdown, not raw JSON (except Keystone fallback which returns raw blocks)

--- a/openspec/changes/archive/2026-09-04-add-notion-address-comments-skill/proposal.md
+++ b/openspec/changes/archive/2026-09-04-add-notion-address-comments-skill/proposal.md
@@ -1,0 +1,31 @@
+# Change: Add notion-address-comments skill
+
+## Why
+
+The existing `/notion` skill is deliberately read-only ("Cannot create, update, or
+delete pages"). Iterating on a Notion page across rounds of inline review comments —
+read each open thread, make the edit it asks for, reply summarizing the change — is a
+repeatable workflow currently done ad hoc with raw MCP tool calls, with no skill
+covering it.
+
+## What Changes
+
+- Add `agents/skills/notion-address-comments/SKILL.md`: given a Notion page with open
+  inline comments, reads each unresolved thread, edits the page to address it, and
+  replies with a short summary of the change, without reprocessing threads already
+  answered.
+- The skill is tool-agnostic in spirit but documents the concrete
+  `mcp__claude_ai_Notion__*` tool calls needed (`notion-get-comments`, `notion-fetch`,
+  `notion-update-page`, `notion-create-comment`) since no alternate vendor path exists
+  for Notion writes today.
+- The skill states explicitly that there is no resolve-thread tool available — threads
+  stay open for the user to resolve manually in the Notion UI.
+- Add a short cross-reference line in `agents/skills/notion/SKILL.md` pointing to the
+  new skill for writes/comment threads.
+- Update `README.md` skill count.
+
+## Impact
+
+- Affected specs: `notion-comment-workflow` (new capability)
+- Affected code: `agents/skills/notion-address-comments/`,
+  `agents/skills/notion/SKILL.md`, `README.md`

--- a/openspec/changes/archive/2026-09-04-add-notion-address-comments-skill/specs/notion-comment-workflow/spec.md
+++ b/openspec/changes/archive/2026-09-04-add-notion-address-comments-skill/specs/notion-comment-workflow/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Notion Comment-Addressing Skill
+
+The repository SHALL provide a `notion-address-comments` skill that, given a Notion
+page with open inline comment threads, reads each unresolved thread, edits the page to
+address what the thread is asking for, and replies to the thread with a short summary
+of the change.
+
+The skill SHALL:
+- Fetch open comment threads rather than assuming all comments need action — resolved
+  threads are excluded by default and SHALL NOT be reprocessed.
+- Re-fetch the page's current content immediately before building each edit, since a
+  stale copy (from an earlier turn, or from the user's own manual edits between turns)
+  produces a failed text match.
+- Track which threads have already been replied to, and only act on a thread again
+  when it has a newer comment posted after the skill's last reply on it.
+- Reply to each addressed thread with a short note describing what changed.
+- State explicitly, when no resolve-thread tool is available, that threads remain open
+  for the user to resolve manually rather than implying they were closed.
+
+#### Scenario: Addressing open comment threads on a Notion page
+
+- **WHEN** a user invokes `notion-address-comments` on a Notion page with unresolved
+  inline comments
+- **THEN** Claude reads each open thread, edits the page to address it, and replies to
+  the thread summarizing the change
+
+#### Scenario: Re-invoking after a prior pass with no new feedback
+
+- **WHEN** a thread already has a reply from a previous invocation and no newer comment
+  since that reply
+- **THEN** the skill SHALL NOT reprocess or reply to that thread again
+
+#### Scenario: No resolve-thread capability available
+
+- **WHEN** the skill has addressed a thread and no tool exists to mark it resolved
+- **THEN** the skill SHALL tell the user the thread remains open for manual resolution
+  in the Notion UI, rather than implying it was resolved

--- a/openspec/changes/archive/2026-09-04-add-notion-address-comments-skill/tasks.md
+++ b/openspec/changes/archive/2026-09-04-add-notion-address-comments-skill/tasks.md
@@ -1,0 +1,23 @@
+## 1. Skill
+
+- [x] 1.1 Write `agents/skills/notion-address-comments/SKILL.md`
+- [x] 1.2 Add cross-reference line in `agents/skills/notion/SKILL.md`
+
+## 2. Docs
+
+- [x] 2.1 Update `README.md` skill count
+
+## 3. Validation
+
+- [x] 3.1 `go install ./...`
+- [x] 3.2 `revive -set_exit_status ./...`
+- [x] 3.3 `go test ./...`
+- [x] 3.4 `bash .github/skill-tests/run_all.sh`
+- [x] 3.5 `bash .github/lint-skills.sh`
+- [x] 3.6 `qlty check --all --no-fix --level=high`
+- [x] 3.7 `qlty smells --all --no-snippets`
+
+## 4. Archive
+
+- [x] 4.1 `openspec archive add-notion-address-comments-skill --yes`
+- [x] 4.2 `openspec validate --strict`

--- a/openspec/specs/notion-comment-workflow/spec.md
+++ b/openspec/specs/notion-comment-workflow/spec.md
@@ -1,0 +1,43 @@
+# notion-comment-workflow Specification
+
+## Purpose
+TBD - created by archiving change add-notion-address-comments-skill. Update Purpose after archive.
+## Requirements
+### Requirement: Notion Comment-Addressing Skill
+
+The repository SHALL provide a `notion-address-comments` skill that, given a Notion
+page with open inline comment threads, reads each unresolved thread, edits the page to
+address what the thread is asking for, and replies to the thread with a short summary
+of the change.
+
+The skill SHALL:
+- Fetch open comment threads rather than assuming all comments need action — resolved
+  threads are excluded by default and SHALL NOT be reprocessed.
+- Re-fetch the page's current content immediately before building each edit, since a
+  stale copy (from an earlier turn, or from the user's own manual edits between turns)
+  produces a failed text match.
+- Track which threads have already been replied to, and only act on a thread again
+  when it has a newer comment posted after the skill's last reply on it.
+- Reply to each addressed thread with a short note describing what changed.
+- State explicitly, when no resolve-thread tool is available, that threads remain open
+  for the user to resolve manually rather than implying they were closed.
+
+#### Scenario: Addressing open comment threads on a Notion page
+
+- **WHEN** a user invokes `notion-address-comments` on a Notion page with unresolved
+  inline comments
+- **THEN** Claude reads each open thread, edits the page to address it, and replies to
+  the thread summarizing the change
+
+#### Scenario: Re-invoking after a prior pass with no new feedback
+
+- **WHEN** a thread already has a reply from a previous invocation and no newer comment
+  since that reply
+- **THEN** the skill SHALL NOT reprocess or reply to that thread again
+
+#### Scenario: No resolve-thread capability available
+
+- **WHEN** the skill has addressed a thread and no tool exists to mark it resolved
+- **THEN** the skill SHALL tell the user the thread remains open for manual resolution
+  in the Notion UI, rather than implying it was resolved
+


### PR DESCRIPTION
Adds a sibling skill to the read-only /notion skill for iterating on a Notion
page against its open inline comment threads: read each unresolved thread,
edit the page to address it, and reply with a short summary of the change.
There is no resolve-thread tool available, so threads stay open for the user
to resolve manually.

Also fixes an unrelated, pre-existing CI failure (agnix flagging
deploy-audit/deploy-validate as missing disable-model-invocation) that was
blocking merge on master independent of this change.

Co-Authored-By: Claude <noreply@anthropic.com>